### PR TITLE
Fixed deserialization error.

### DIFF
--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blocksummary/MicroGTUPerEuro.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blocksummary/MicroGTUPerEuro.java
@@ -5,21 +5,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.math.BigInteger;
 import java.util.List;
 
 @Getter
 @ToString
 public final class MicroGTUPerEuro {
-    private final int denominator;
-    private final int numerator;
+    private final BigInteger denominator;
+    private final BigInteger numerator;
     private final int threshold;
     private final List<Integer> authorizedKeys;
     private final int nextSequenceNumber;
     private final List<Object> queue;
 
     @JsonCreator
-    MicroGTUPerEuro(@JsonProperty("denominator") int denominator,
-                    @JsonProperty("numerator") int numerator,
+    MicroGTUPerEuro(@JsonProperty("denominator") BigInteger denominator,
+                    @JsonProperty("numerator") BigInteger numerator,
                     @JsonProperty("threshold") int threshold,
                     @JsonProperty("authorizedKeys") List<Integer> authorizedKeys,
                     @JsonProperty("nextSequenceNumber") int nextSequenceNumber,


### PR DESCRIPTION
## Purpose

Fix deserialization error related to MicroGTUPerEuro.java in particular the types for the fields `denominator` and `numerator` were wrong. 

## Changes

Fixed the types such that it can deserialize uint64 values. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
