### PR TITLE
Support for account alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased changes
+- Support for account alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
 
 ## Unreleased changes
+
+## 1.0.2
 - Support for account alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## Unreleased changes
 
-## 1.0.2
+## 1.1.0
 - Support for account alias.

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.2</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
@@ -1,16 +1,22 @@
 package com.concordium.sdk.transactions;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.val;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
 
 @ToString
+@EqualsAndHashCode
 public final class AccountAddress {
     public static final int BYTES = 32;
     private final static int VERSION = 1;
+    private final static int ACCOUNT_ADDRESS_PREFIX_SIZE = 29;
+    private final static int ALIAS_MAX_VALUE = 2 << 24;
 
     @Getter
     private final byte[] bytes;
@@ -30,6 +36,25 @@ public final class AccountAddress {
     public static AccountAddress from(String address) {
         val addressBytes = Base58.decodeChecked(VERSION, address);
         return AccountAddress.from(addressBytes);
+    }
+
+    public AccountAddress newAlias(int alias) {
+        if (alias < 0) {
+            throw new NumberFormatException("Alias must be non negative");
+        }
+        if (alias > ALIAS_MAX_VALUE) {
+            alias = alias % ALIAS_MAX_VALUE;
+        }
+        val buffer = ByteBuffer.allocate(Integer.BYTES);
+        buffer.putInt(alias);
+        val newAlias = this.bytes.clone();
+        System.arraycopy(buffer.array(), 1, newAlias, ACCOUNT_ADDRESS_PREFIX_SIZE, 3);
+        return AccountAddress.from(newAlias);
+    }
+
+    public boolean isAliasOf(AccountAddress other) {
+        return Arrays.equals(Arrays.copyOfRange(this.bytes, 0, ACCOUNT_ADDRESS_PREFIX_SIZE),
+                Arrays.copyOfRange(other.bytes, 0, ACCOUNT_ADDRESS_PREFIX_SIZE));
     }
 
     public static AccountAddress from(byte[] addressBytes) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
@@ -16,7 +16,7 @@ public final class AccountAddress {
     public static final int BYTES = 32;
     private final static int VERSION = 1;
     private final static int ACCOUNT_ADDRESS_PREFIX_SIZE = 29;
-    private final static int ALIAS_MAX_VALUE = 2 << 24;
+    private final static int ALIAS_MAX_VALUE = (2 << 23); // 2^24
 
     @Getter
     private final byte[] bytes;
@@ -40,10 +40,10 @@ public final class AccountAddress {
 
     public AccountAddress newAlias(int alias) {
         if (alias < 0) {
-            throw new NumberFormatException("Alias must be non negative");
+            throw new NumberFormatException("Alias must be non negative.");
         }
         if (alias > ALIAS_MAX_VALUE) {
-            alias = alias % ALIAS_MAX_VALUE;
+            throw new IllegalArgumentException("Alias too large, the provided alias must not be larger than 2^24.");
         }
         val buffer = ByteBuffer.allocate(Integer.BYTES);
         buffer.putInt(alias);

--- a/concordium-sdk/src/test/java/com/concordium/sdk/transactions/AccountAddressTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/transactions/AccountAddressTest.java
@@ -46,8 +46,6 @@ public class AccountAddressTest {
         assertTrue(base.isAliasOf(base));
         assertTrue(base.newAlias(1).isAliasOf(base));
         assertTrue(base.newAlias(197121).isAliasOf(base));
-        assertTrue(base.newAlias(1 + 2 * 256 + 3 * 256 * 256 + 4 * 256 * 256 * 256).isAliasOf(base));
-        assertTrue(base.newAlias(2147483647).isAliasOf(base));
         assertFalse(AccountAddress.from("3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P").isAliasOf(base));
     }
 
@@ -55,8 +53,15 @@ public class AccountAddressTest {
     public void testCreateAccountAlias() {
         val base = AccountAddress.from("2wkH4kHMn2WPndf8CxmsoFkX93ouZMJUwTBFSZpDCeNeGWa7dj");
         assertEquals("2wkH4kHMn2WPndf8CxmsoFkX93ouZMJUwTBFSZpDBez9cfL8oC", base.newAlias(1 + 2 * 256 + 3 * 65536).encoded());
-        assertEquals("2wkH4kHMn2WPndf8CxmsoFkX93ouZMJUwTBFSZpDBez9cfL8oC", base.newAlias(1 + 2 * 256 + 3 * 256 * 256 + 4 * 256 * 256 * 256).encoded());
         assertEquals(base.newAlias(0).encoded(), base.newAlias(16777216).encoded());
-        assertEquals(base.newAlias(1).encoded(), base.newAlias((2 << 24) + 1).encoded()); // max alias size is 2^24 = 16777216
+
+        try {
+            base.newAlias((2 << 23) + 1);
+            fail("Expected invalid alias.");
+        } catch (IllegalArgumentException e) {
+            if (!e.getMessage().contains("Alias too large, the provided alias must not be larger than 2^24.")) {
+                fail("Unexpected error: " + e.getMessage());
+            }
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Aims to fix #15 

## Changes

Expanded the AccountAddress type with the following two methods: 

`AccountAddress newAlias(int alias)`
Creates a new alias from an `AccountAddress`

`boolean isAliasOf(AccountAddress other)`
Checks whether an `AccountAddress` is an alias of the other.

There is now also a CHANGELOG.md in the root of the repository which should be used for the future.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
