### PR TITLE
Support for v1 SC events.

### DIFF
--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/ContractInitializedResult.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/ContractInitializedResult.java
@@ -17,14 +17,15 @@ public final class ContractInitializedResult extends TransactionResultEvent {
     private GTUAmount amount;
     private final String initName;
     private final List<String> events;
-
+    private final int version;
 
     @JsonCreator
     ContractInitializedResult(@JsonProperty("ref") String ref,
                               @JsonProperty("address") ContractAddress address,
                               @JsonProperty("amount") String amount,
                               @JsonProperty("initName") String initName,
-                              @JsonProperty("events") List<String> events) {
+                              @JsonProperty("events") List<String> events,
+                              @JsonProperty("version") int version) {
         this.ref = ref;
         this.address = address;
         if(!Objects.isNull(amount)) {
@@ -32,5 +33,6 @@ public final class ContractInitializedResult extends TransactionResultEvent {
         }
         this.initName = initName;
         this.events = events;
+        this.version = version;
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/ContractUpdated.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/ContractUpdated.java
@@ -19,6 +19,7 @@ public class ContractUpdated extends TransactionResultEvent {
     private final String receiveName;
     private final List<String> events;
     private final String message;
+    private final int version;
 
     @JsonCreator
     ContractUpdated(@JsonProperty("amount") String amount,
@@ -26,7 +27,8 @@ public class ContractUpdated extends TransactionResultEvent {
                     @JsonProperty("address") Map<String, Object> address,
                     @JsonProperty("receiveName") String receiveName,
                     @JsonProperty("events") List<String> events,
-                    @JsonProperty("message") String message) {
+                    @JsonProperty("message") String message,
+                    @JsonProperty("version") int version) {
         this.instigator = AbstractAccount.parseAccount(instigator);
         this.address = (ContractAddress) AbstractAccount.parseAccount(address);
         this.receiveName = receiveName;
@@ -35,5 +37,6 @@ public class ContractUpdated extends TransactionResultEvent {
         if (!Objects.isNull(amount)) {
             this.amount = GTUAmount.fromMicro(amount);
         }
+        this.version = version;
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/InterruptedResult.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/InterruptedResult.java
@@ -1,0 +1,24 @@
+package com.concordium.sdk.responses.transactionstatus;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@ToString
+public class InterruptedResult extends TransactionResultEvent {
+
+    private final ContractAddress address;
+    private final List<String> events;
+
+    @JsonCreator
+    InterruptedResult(@JsonProperty("address") Map<String, Object> address,
+                      @JsonProperty("events") List<String> events){
+        this.address = (ContractAddress) AbstractAccount.parseAccount(address);
+        this.events = events;
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/ResumedResult.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/ResumedResult.java
@@ -1,0 +1,22 @@
+package com.concordium.sdk.responses.transactionstatus;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@ToString
+public class ResumedResult extends TransactionResultEvent {
+    private final ContractAddress address;
+    private final boolean success;
+
+    @JsonCreator
+    ResumedResult(@JsonProperty("address") Map<String, Object> address,
+                  @JsonProperty("success") boolean success) {
+        this.success = success;
+        this.address = (ContractAddress) AbstractAccount.parseAccount(address);
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/TransactionResult.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/TransactionResult.java
@@ -35,7 +35,9 @@ public final class TransactionResult {
             @JsonSubTypes.Type(value = TransferredResult.class, name = "Transferred"),
             @JsonSubTypes.Type(value = TransferMemoResult.class, name = "TransferMemo"),
             @JsonSubTypes.Type(value = EncryptedAmountsRemovedResult.class, name = "EncryptedAmountsRemoved"),
-            @JsonSubTypes.Type(value = ContractUpdated.class, name = "Updated")
+            @JsonSubTypes.Type(value = ContractUpdated.class, name = "Updated"),
+            @JsonSubTypes.Type(value = InterruptedResult.class, name = "Interrupted"),
+            @JsonSubTypes.Type(value = ResumedResult.class, name = "Resumed")
     })
     private final List<TransactionResultEvent> events;
     private final Outcome outcome;


### PR DESCRIPTION
## Purpose

Adding support for v1 smart contract events. 
This PR aims to partially solve https://github.com/Concordium/concordium-java-sdk/issues/17


## Changes

Added support for two new contract execution events:

- `Interrupted` 
- `Resumed`

Further the `Updated` and `Initialization` events are further expanded with a new `contractVersion` field describing whether the smart contract is a v0 or v1 contract. 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

