### PR TITLE
Support for GetBlocksAtHeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Support for `getBlocksAtHeight`
 
 ## 1.1.0
 - Support for account alias.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Throws a `BlockNotFoundException` if the block was not found.
 
 - `getBlocksAtHeight`
 ```java
-BlocksAtHeight getBlocksAtHeight(long height) throws BlockNotFoundException
+BlocksAtHeight getBlocksAtHeight(BlocksAtHeightRequest height) throws BlockNotFoundException
 ```
 Retrieves the `BlocksAtHeight` at the given height if one or more was found.
 Throws a `BlockNotFoundException` if no blocks were found.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ BlockSummary getBlockSummary(Hash blockHash) throws BlockNotFoundException
 Retrieves the `BlockSummary` of a block given by the provided block `hash`.
 Throws a `BlockNotFoundException` if the block was not found.
 
+- `getBlocksAtHeight`
+```java
+BlocksAtHeight getBlocksAtHeight(long height) throws BlockNotFoundException
+```
+Retrieves the `BlocksAtHeight` at the given height if one or more was found.
+Throws a `BlockNotFoundException` if no blocks were found.
+
 ## Transactions
 
 - `Hash sendTransaction(Transaction transaction) throws TransactionRejectionException`

--- a/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
@@ -42,7 +42,7 @@ public class BlocksAtHeightRequest {
 
     /**
      * Request blocks at a relative height wrt. a specified genesis index.
-     * @param height the relative height.
+     * @param height the height counting from the last protocol update, 
      * @param genesisIndex the genesis index.
      * @param restrictedToGenesisIndex if true then only blocks at the specified genesis index will be returned.
      * @return the request.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
@@ -1,0 +1,57 @@
+package com.concordium.sdk;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class BlocksAtHeightRequest {
+    private final Type type;
+    private final long height;
+
+    private int genesisIndex;
+    private boolean restrictedToGenesisIndex;
+
+    private BlocksAtHeightRequest(Type type, long height) {
+        this.type = type;
+        this.height = height;
+    }
+
+    public BlocksAtHeightRequest(Type relative, long height, int genesisIndex, boolean restrictedToGenesisIndex) {
+        this(relative, height);
+        this.genesisIndex = genesisIndex;
+        this.restrictedToGenesisIndex = restrictedToGenesisIndex;
+    }
+
+    public static BlocksAtHeightRequest newAbsolute(long height) {
+        return new BlocksAtHeightRequest(Type.ABSOLUTE, height);
+    }
+
+    public static BlocksAtHeightRequest newRelative(long height, int genesisIndex, boolean restrictedToGenesisIndex) {
+        return new BlocksAtHeightRequest(Type.RELATIVE, height, genesisIndex, restrictedToGenesisIndex);
+    }
+
+    public String toPrettyExceptionMessage() {
+        switch (this.type) {
+            case ABSOLUTE:
+                return "Requested height: " + this.getHeight();
+            case RELATIVE:
+                return "Requested height: " + this.getHeight() + " genesis index " + this.getGenesisIndex() + " " + getMaybeRestrictedString();
+            default:
+                return "Invalid BlockHeightRequest.Type";
+        }
+    }
+
+    private String getMaybeRestrictedString() {
+        if (this.type == Type.RELATIVE) {
+            return "(query was restricted to the genesis)";
+        }
+        return "";
+    }
+
+
+    public enum Type {
+        ABSOLUTE,
+        RELATIVE
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
@@ -3,6 +3,14 @@ package com.concordium.sdk;
 import lombok.Getter;
 import lombok.ToString;
 
+/**
+ * Request type for {@link Client#getBlocksAtHeight(BlocksAtHeightRequest)}
+ * This type allows for requesting blocks at a specified height either by an absolute
+ * value or by a relative one.
+ *
+ * Refer to {@link BlocksAtHeightRequest#newAbsolute(long)} and {@link BlocksAtHeightRequest#newRelative(long, int, boolean)}
+ * for creating the request.
+ */
 @Getter
 @ToString
 public class BlocksAtHeightRequest {
@@ -23,10 +31,22 @@ public class BlocksAtHeightRequest {
         this.restrictedToGenesisIndex = restrictedToGenesisIndex;
     }
 
+    /**
+     * Request blocks at an absolute height.
+     * @param height the absolute height.
+     * @return the request.
+     */
     public static BlocksAtHeightRequest newAbsolute(long height) {
         return new BlocksAtHeightRequest(Type.ABSOLUTE, height);
     }
 
+    /**
+     * Request blocks at a relative height wrt. a specified genesis index.
+     * @param height the relative height.
+     * @param genesisIndex the genesis index.
+     * @param restrictedToGenesisIndex if true then only blocks at the specified genesis index will be returned.
+     * @return the request.
+     */
     public static BlocksAtHeightRequest newRelative(long height, int genesisIndex, boolean restrictedToGenesisIndex) {
         return new BlocksAtHeightRequest(Type.RELATIVE, height, genesisIndex, restrictedToGenesisIndex);
     }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/BlocksAtHeightRequest.java
@@ -33,7 +33,7 @@ public class BlocksAtHeightRequest {
 
     /**
      * Request blocks at an absolute height.
-     * @param height the absolute height.
+     * @param height the absolute height, i.e., height starting from the genesis block
      * @return the request.
      */
     public static BlocksAtHeightRequest newAbsolute(long height) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
@@ -4,6 +4,7 @@ import com.concordium.sdk.exceptions.AccountNotFoundException;
 import com.concordium.sdk.exceptions.BlockNotFoundException;
 import com.concordium.sdk.exceptions.TransactionNotFoundException;
 import com.concordium.sdk.exceptions.TransactionRejectionException;
+import com.concordium.sdk.responses.BlocksAtHeight;
 import com.concordium.sdk.responses.accountinfo.AccountInfo;
 import com.concordium.sdk.responses.blocksummary.BlockSummary;
 import com.concordium.sdk.responses.consensusstatus.ConsensusStatus;
@@ -151,6 +152,25 @@ public final class Client {
             throw BlockNotFoundException.from(blockHash);
         }
         return blockSummary;
+    }
+
+    /**
+     * Retrieves a {@link BlocksAtHeight}
+     * @param height the height to query blocks for.
+     * @return A {@link BlocksAtHeight} if one or more blocks was present at the given height.
+     * @throws BlockNotFoundException if no blocks were present at the given height.
+     */
+    public BlocksAtHeight getBlocksAtHeight(long height) throws BlockNotFoundException {
+        val request = ConcordiumP2PRpc.BlockHeight.getDefaultInstance()
+                .newBuilderForType()
+                .setBlockHeight(height)
+                .build();
+        val response = blockingStub.getBlocksAtHeight(request);
+        val blocksAtHeight = BlocksAtHeight.fromJson(response.getValue());
+        if (Objects.isNull(blocksAtHeight)) {
+            throw BlockNotFoundException.from(height);
+        }
+        return blocksAtHeight;
     }
 
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
@@ -156,7 +156,7 @@ public final class Client {
 
     /**
      * Retrieves a {@link BlocksAtHeight}
-     * @param height the height to query blocks for.
+     * @param height the {@link BlocksAtHeightRequest} request.
      * @return A {@link BlocksAtHeight} if one or more blocks was present at the given height.
      * @throws BlockNotFoundException if no blocks were present at the given height.
      */

--- a/concordium-sdk/src/main/java/com/concordium/sdk/exceptions/BlockNotFoundException.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/exceptions/BlockNotFoundException.java
@@ -3,9 +3,10 @@ package com.concordium.sdk.exceptions;
 import com.concordium.sdk.transactions.Hash;
 import lombok.Getter;
 
+@Getter
 public final class BlockNotFoundException extends Exception {
-    @Getter
-    private final Hash blockHash;
+    private Hash blockHash;
+    private long atHeight;
 
     /**
      * Creates a new {@link BlockNotFoundException} from a {@link Hash}
@@ -20,7 +21,16 @@ public final class BlockNotFoundException extends Exception {
         this.blockHash = blockHash;
     }
 
+    private BlockNotFoundException(long height) {
+        super("Block not found at height " + height);
+        this.atHeight = height;
+    }
+
     public static BlockNotFoundException from(Hash blockHash) {
         return new BlockNotFoundException(blockHash);
+    }
+
+    public static BlockNotFoundException from(long height) {
+        return new BlockNotFoundException(height);
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/exceptions/BlockNotFoundException.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/exceptions/BlockNotFoundException.java
@@ -1,28 +1,29 @@
 package com.concordium.sdk.exceptions;
 
+import com.concordium.sdk.BlocksAtHeightRequest;
 import com.concordium.sdk.transactions.Hash;
 import lombok.Getter;
 
 @Getter
 public final class BlockNotFoundException extends Exception {
     private Hash blockHash;
-    private long atHeight;
+    private BlocksAtHeightRequest atHeight;
 
     /**
      * Creates a new {@link BlockNotFoundException} from a {@link Hash}
      * This happens when a block could not be found.
-     *
+     * <p>
      * Use {@link BlockNotFoundException#from(Hash)} to instantiate.
      *
      * @param blockHash The block hash
      */
     private BlockNotFoundException(Hash blockHash) {
-        super("Block not found " + blockHash.asHex());
+        super("Block not found: " + blockHash.asHex());
         this.blockHash = blockHash;
     }
 
-    private BlockNotFoundException(long height) {
-        super("Block not found at height " + height);
+    private BlockNotFoundException(BlocksAtHeightRequest height) {
+        super("Block not found: " + height.toPrettyExceptionMessage());
         this.atHeight = height;
     }
 
@@ -30,7 +31,7 @@ public final class BlockNotFoundException extends Exception {
         return new BlockNotFoundException(blockHash);
     }
 
-    public static BlockNotFoundException from(long height) {
+    public static BlockNotFoundException from(BlocksAtHeightRequest height) {
         return new BlockNotFoundException(height);
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/BlocksAtHeight.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/BlocksAtHeight.java
@@ -1,0 +1,32 @@
+package com.concordium.sdk.responses;
+
+import com.concordium.sdk.serializing.JsonMapper;
+import com.concordium.sdk.transactions.Hash;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * BlocksAtHeight
+ */
+@Getter
+@ToString
+public class BlocksAtHeight {
+    private final List<Hash> blocks;
+
+    @JsonCreator
+    BlocksAtHeight(List<Hash> blocks) {
+        this.blocks = blocks;
+    }
+
+    public static BlocksAtHeight fromJson(String blocksAtHeightJsonString) {
+        try {
+            return JsonMapper.INSTANCE.readValue(blocksAtHeightJsonString, BlocksAtHeight.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Cannot parse AccountInfo JSON", e);
+        }
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/BlocksAtHeight.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/BlocksAtHeight.java
@@ -26,7 +26,7 @@ public class BlocksAtHeight {
         try {
             return JsonMapper.INSTANCE.readValue(blocksAtHeightJsonString, BlocksAtHeight.class);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Cannot parse AccountInfo JSON", e);
+            throw new IllegalArgumentException("Cannot parse BlocksAtHeight JSON", e);
         }
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
@@ -33,11 +33,24 @@ public final class AccountAddress {
         return Base58.encodeChecked(VERSION, bytes);
     }
 
+    /**
+     * Create a new {@link AccountAddress} given the base58 encoded address.
+     * PRECONDITION: The encoded account address must conform to the {@link AccountAddress#VERSION}
+     * @param address A base58 encoded address.
+     * @return The created {@link AccountAddress}
+     */
     public static AccountAddress from(String address) {
         val addressBytes = Base58.decodeChecked(VERSION, address);
         return AccountAddress.from(addressBytes);
     }
 
+    /**
+     * Create a new alias.
+     * @param alias the counter to be used for the alias.
+     *              The alias counter must be non-negative and the max value allowed is {@link AccountAddress#ALIAS_MAX_VALUE}
+     * @return a new {@link AccountAddress} for the specified alias.
+     *
+     */
     public AccountAddress newAlias(int alias) {
         if (alias < 0) {
             throw new NumberFormatException("Alias must be non negative.");
@@ -52,6 +65,11 @@ public final class AccountAddress {
         return AccountAddress.from(newAlias);
     }
 
+    /**
+     * Check if one {@link AccountAddress} is an <i>alias</i> of another.
+     * @param other the other {@link AccountAddress}
+     * @return whether this {@link AccountAddress} is an alias of the other.
+     */
     public boolean isAliasOf(AccountAddress other) {
         return Arrays.equals(Arrays.copyOfRange(this.bytes, 0, ACCOUNT_ADDRESS_PREFIX_SIZE),
                 Arrays.copyOfRange(other.bytes, 0, ACCOUNT_ADDRESS_PREFIX_SIZE));

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Base58.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Base58.java
@@ -150,12 +150,12 @@ class Base58 {
 
     static byte[] decodeChecked(int version, String input) {
         byte[] decoded = decode(input);
+        if (decoded.length < 4) {
+            throw new IllegalArgumentException("Input too short: " + decoded.length);
+        }
         byte versionByte = decoded[0];
         if (versionByte != version) {
             throw new IllegalArgumentException("Invalid version");
-        }
-        if (decoded.length < 4) {
-            throw new IllegalArgumentException("Input too short: " + decoded.length);
         }
         byte[] data = Arrays.copyOfRange(decoded, 0, decoded.length - 4);
         byte[] expectedChecksum = Arrays.copyOfRange(decoded, decoded.length - 4, decoded.length);


### PR DESCRIPTION
## Purpose

Support for GetBlocksAtHeight

## Changes

The Client API now exposes 
`BlocksAtHeight getBlocksAtHeight(long height) throws BlockNotFoundException`

If one or more blocks was found at the given height then it returns a list of block hashes. 
If no blocks were found the a `BlockNotFoundException` is thrown.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

