### PR TITLE
Add methods for deserializing transactions and block items. And another endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 1.3.0
+- Support for transaction deserialization.
+- Support for `getBlockInfo`.
+
 ## 1.2.0
 - Support for `getBlocksAtHeight`
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,16 @@ try {
 ConsensusStatus consensusStatus = client.getConsensusStatus();
 ```
 
+### getBlockInfo
+```java
+Hash blockHash = Hash.from("3d52e63350bfd21676ecbf6ce29688e3be6bff86cbacfe138aac107b64d29ba1");
+try {
+    BlockInfo blockInfo = client.getBlockInfo(blockHash);
+} catch(BlockNotFoundException e) {
+    Log.Err(e.getMessage());
+}
+```
+
 ### getBlockSummary
 ```java
 Hash blockHash = Hash.from("3d52e63350bfd21676ecbf6ce29688e3be6bff86cbacfe138aac107b64d29ba1");

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.13.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
@@ -6,6 +6,7 @@ import com.concordium.sdk.exceptions.TransactionNotFoundException;
 import com.concordium.sdk.exceptions.TransactionRejectionException;
 import com.concordium.sdk.responses.BlocksAtHeight;
 import com.concordium.sdk.responses.accountinfo.AccountInfo;
+import com.concordium.sdk.responses.blockinfo.BlockInfo;
 import com.concordium.sdk.responses.blocksummary.BlockSummary;
 import com.concordium.sdk.responses.consensusstatus.ConsensusStatus;
 import com.concordium.sdk.responses.transactionstatus.TransactionStatus;
@@ -154,6 +155,25 @@ public final class Client {
             throw BlockNotFoundException.from(blockHash);
         }
         return blockSummary;
+    }
+
+    /**
+     * Retrieves a {@link BlockInfo}
+     * @param blockHash the block {@link Hash} to query.
+     * @return A {@link BlockInfo} for the block
+     * @throws BlockNotFoundException If the block was not found.
+     */
+    public BlockInfo getBlockInfo(Hash blockHash) throws BlockNotFoundException {
+        val request = ConcordiumP2PRpc.BlockHash.getDefaultInstance()
+                .newBuilderForType()
+                .setBlockHashBytes(ByteString.copyFromUtf8(blockHash.asHex()))
+                .build();
+        val response = blockingStub.getBlockInfo(request);
+        val blockInfo = BlockInfo.fromJson(response.getValue());
+        if (Objects.isNull(blockInfo)) {
+            throw BlockNotFoundException.from(blockHash);
+        }
+        return blockInfo;
     }
 
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Client.java
@@ -24,6 +24,8 @@ import lombok.val;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static com.concordium.sdk.transactions.Transaction.DEFAULT_NETWORK_ID;
+
 /**
  * The Client is responsible for sending requests to the node.
  */

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
@@ -85,8 +85,8 @@ public class BlockInfo {
      */
     private Integer transactionCount;
     /**
-     * / Time when the block was added to the node's tree. This is a subjective
-     * / (i.e., node specific) value.
+     *  Time when the block was added to the node's tree. This is a subjective
+     *  (i.e., node specific) value.
      */
     private OffsetDateTime blockArriveTime;
     public static BlockInfo fromJson(String blockInfoJsonString) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
@@ -15,21 +15,79 @@ import java.time.OffsetDateTime;
 @RequiredArgsConstructor
 @Getter
 public class BlockInfo {
+    /**
+     * / Hash of the block.
+     */
     private Hash blockHash;
+    /**
+     * / The total energy consumption of transactions in the block.
+     */
     private Integer transactionEnergyCost;
+    /**
+     * / Identity of the baker of the block. For non-genesis blocks the value is
+     * / non-null.
+     */
     private Integer blockBaker;
+    /**
+     * / Hash of the block state at the end of the given block.
+     */
     private Hash blockStateHash;
+    /**
+     * / Slot time of the slot the block is in. In contrast to
+     * / {@link BlockInfo#blockArriveTime} this is an objective value, all nodes
+     * / agree on it.
+     */
     private OffsetDateTime blockSlotTime;
+    /**
+     * / Parent block pointer.
+     */
     private Hash blockParent;
+    /**
+     * / Time when the block was first received by the node. This can be in
+     * / principle quite different from the arrive time if, e.g., block execution
+     * / takes a long time, or the block must wait for the arrival of its parent.
+     */
     private OffsetDateTime blockReceiveTime;
+    /**
+     * / The genesis index for this block. This counts the number of protocol
+     * / updates that have preceded this block, and defines the era of the
+     * / block.
+     */
     private Integer genesisIndex;
+    /**
+     * / Slot number of the slot the block is in.
+     */
     private Integer blockSlot;
+    /**
+     * / Whether the block is finalized or not.
+     */
     private Boolean finalized;
+    /**
+     * / The height of this block relative to the (re)genesis block of its era.
+     */
     private Integer eraBlockHeight;
+    /**
+     * / Pointer to the last finalized block. Each block has a pointer to a
+     * / specific finalized block that existed at the time the block was
+     * / produced.
+     */
     private Hash blockLastFinalized;
+    /**
+     * Size of all the transactions in the block in bytes.
+     */
     private Integer transactionsSize;
+    /**
+     * / Height of the block from genesis.
+     */
     private Integer blockHeight;
+    /**
+     * / The number of transactions in the block.
+     */
     private Integer transactionCount;
+    /**
+     * / Time when the block was added to the node's tree. This is a subjective
+     * / (i.e., node specific) value.
+     */
     private OffsetDateTime blockArriveTime;
     public static BlockInfo fromJson(String blockInfoJsonString) {
         try {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
@@ -16,60 +16,60 @@ import java.time.OffsetDateTime;
 @Getter
 public class BlockInfo {
     /**
-     * / Hash of the block.
+     *  Hash of the block.
      */
     private Hash blockHash;
     /**
-     * / The total energy consumption of transactions in the block.
+     *  The total energy consumption of transactions in the block.
      */
     private Integer transactionEnergyCost;
     /**
-     * / Identity of the baker of the block. For non-genesis blocks the value is
-     * / non-null.
+     *  Identity of the baker of the block. For non-genesis blocks the value is
+     *  non-null.
      */
     private Integer blockBaker;
     /**
-     * / Hash of the block state at the end of the given block.
+     *  Hash of the block state at the end of the given block.
      */
     private Hash blockStateHash;
     /**
-     * / Slot time of the slot the block is in. In contrast to
-     * / {@link BlockInfo#blockArriveTime} this is an objective value, all nodes
-     * / agree on it.
+     *  Slot time of the slot the block is in. In contrast to
+     *  {@link BlockInfo#blockArriveTime} this is an objective value, all nodes
+     *  agree on it.
      */
     private OffsetDateTime blockSlotTime;
     /**
-     * / Parent block pointer.
+     *  Parent block pointer.
      */
     private Hash blockParent;
     /**
-     * / Time when the block was first received by the node. This can be in
-     * / principle quite different from the arrive time if, e.g., block execution
-     * / takes a long time, or the block must wait for the arrival of its parent.
+     *  Time when the block was first received by the node. This can be in
+     *  principle quite different from the arrive time if, e.g., block execution
+     *  takes a long time, or the block must wait for the arrival of its parent.
      */
     private OffsetDateTime blockReceiveTime;
     /**
-     * / The genesis index for this block. This counts the number of protocol
-     * / updates that have preceded this block, and defines the era of the
-     * / block.
+     *  The genesis index for this block. This counts the number of protocol
+     *  updates that have preceded this block, and defines the era of the
+     *  block.
      */
     private Integer genesisIndex;
     /**
-     * / Slot number of the slot the block is in.
+     *  Slot number of the slot the block is in.
      */
     private Integer blockSlot;
     /**
-     * / Whether the block is finalized or not.
+     *  Whether the block is finalized or not.
      */
     private Boolean finalized;
     /**
-     * / The height of this block relative to the (re)genesis block of its era.
+     *  The height of this block relative to the (re)genesis block of its era.
      */
     private Integer eraBlockHeight;
     /**
-     * / Pointer to the last finalized block. Each block has a pointer to a
-     * / specific finalized block that existed at the time the block was
-     * / produced.
+     *  Pointer to the last finalized block. Each block has a pointer to a
+     *  specific finalized block that existed at the time the block was
+     *  produced.
      */
     private Hash blockLastFinalized;
     /**
@@ -77,11 +77,11 @@ public class BlockInfo {
      */
     private Integer transactionsSize;
     /**
-     * / Height of the block from genesis.
+     *  Height of the block from genesis.
      */
     private Integer blockHeight;
     /**
-     * / The number of transactions in the block.
+     *  The number of transactions in the block.
      */
     private Integer transactionCount;
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockinfo/BlockInfo.java
@@ -1,0 +1,42 @@
+package com.concordium.sdk.responses.blockinfo;
+
+import com.concordium.sdk.responses.accountinfo.AccountInfo;
+import com.concordium.sdk.serializing.JsonMapper;
+import com.concordium.sdk.transactions.Hash;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+
+@ToString
+@Data
+@RequiredArgsConstructor
+@Getter
+public class BlockInfo {
+    private Hash blockHash;
+    private Integer transactionEnergyCost;
+    private Integer blockBaker;
+    private Hash blockStateHash;
+    private OffsetDateTime blockSlotTime;
+    private Hash blockParent;
+    private OffsetDateTime blockReceiveTime;
+    private Integer genesisIndex;
+    private Integer blockSlot;
+    private Boolean finalized;
+    private Integer eraBlockHeight;
+    private Hash blockLastFinalized;
+    private Integer transactionsSize;
+    private Integer blockHeight;
+    private Integer transactionCount;
+    private OffsetDateTime blockArriveTime;
+    public static BlockInfo fromJson(String blockInfoJsonString) {
+        try {
+            return JsonMapper.INSTANCE.readValue(blockInfoJsonString, BlockInfo.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Cannot parse BlockInfo JSON", e);
+        }
+    }
+
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/serializing/JsonMapper.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/serializing/JsonMapper.java
@@ -2,10 +2,11 @@ package com.concordium.sdk.serializing;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public final class JsonMapper {
     public final static ObjectMapper INSTANCE =
             new ObjectMapper()
-                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .registerModule(new JavaTimeModule());
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
@@ -84,4 +84,10 @@ public final class AccountAddress {
         }
         return new AccountAddress(addressBytes);
     }
+
+    public static AccountAddress fromBytes(ByteBuffer source) {
+        byte[] addressBytes = new byte[BYTES];
+        source.get(addressBytes);
+        return AccountAddress.from(addressBytes);
+    }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
@@ -1,10 +1,14 @@
 package com.concordium.sdk.transactions;
 
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.val;
 
 import java.nio.ByteBuffer;
 
+@EqualsAndHashCode
+@ToString
 final class AccountTransaction {
     private final TransactionSignature signature;
     private final TransactionHeader header;
@@ -29,5 +33,23 @@ final class AccountTransaction {
 
     BlockItem toBlockItem() {
         return BlockItem.from(this);
+    }
+
+    public static AccountTransaction fromBytes(ByteBuffer source) {
+        val signature = TransactionSignature.fromBytes(source);
+        val header = TransactionHeader.fromBytes(source);
+        byte tag = source.get();
+        Payload payload;
+        switch (tag) {
+            case 3:
+                payload = Transfer.fromBytes(source);
+                break;
+            case 22:
+                payload = TransferWithMemo.fromBytes(source);
+                break;
+            default:
+                throw new UnsupportedOperationException("Only transfers and transfers with memo are currently supported.");
+        }
+        return new AccountTransaction(signature, header, payload);
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
@@ -1,13 +1,14 @@
 package com.concordium.sdk.transactions;
 
-
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.val;
 
 import java.nio.ByteBuffer;
 
 @EqualsAndHashCode
+@Getter
 @ToString
 final class AccountTransaction {
     private final TransactionSignature signature;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItem.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItem.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.val;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
 @EqualsAndHashCode
@@ -18,6 +19,18 @@ final class BlockItem {
     private BlockItem(AccountTransaction accountTransaction) {
         this.type = BlockItemType.ACCOUNT_TRANSACTION;
         this.accountTransaction = accountTransaction;
+    }
+
+    @Nullable
+    /**
+     * Retrieve the account transaction from the block item, if the block item contains it. Otherwise, returns null.
+     */
+    public AccountTransaction getAccountTransaction() {
+        if (type == BlockItemType.ACCOUNT_TRANSACTION) {
+            return accountTransaction;
+        } else {
+            return null;
+        }
     }
 
     public static BlockItem from(AccountTransaction accountTransaction) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItem.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItem.java
@@ -21,10 +21,10 @@ final class BlockItem {
         this.accountTransaction = accountTransaction;
     }
 
-    @Nullable
     /**
      * Retrieve the account transaction from the block item, if the block item contains it. Otherwise, returns null.
      */
+    @Nullable
     public AccountTransaction getAccountTransaction() {
         if (type == BlockItemType.ACCOUNT_TRANSACTION) {
             return accountTransaction;
@@ -58,7 +58,7 @@ final class BlockItem {
         return buffer.array();
     }
 
-    public static BlockItem fromBytes(ByteBuffer source) {
+    static BlockItem fromBytes(ByteBuffer source) {
         val kind = BlockItemType.fromBytes(source);
         switch (kind) {
             case ACCOUNT_TRANSACTION:
@@ -75,7 +75,7 @@ final class BlockItem {
 
     public static BlockItem fromVersionedBytes(ByteBuffer source) {
         byte tag = source.get();
-        if (tag == 0) {
+        if ((int)tag == VERSION) {
             return BlockItem.fromBytes(source);
         } else {
             throw new UnsupportedOperationException("Only block items in version 0 format are supported.");

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItem.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItem.java
@@ -1,10 +1,14 @@
 package com.concordium.sdk.transactions;
 
 import com.concordium.sdk.crypto.SHA256;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import lombok.val;
 
 import java.nio.ByteBuffer;
 
+@EqualsAndHashCode
+@ToString
 final class BlockItem {
     private static final int VERSION_SIZE = 1;
     private static final int VERSION = 0;
@@ -39,5 +43,29 @@ final class BlockItem {
         buffer.put(type.getByte());
         buffer.put(accountTransactionBytes);
         return buffer.array();
+    }
+
+    public static BlockItem fromBytes(ByteBuffer source) {
+        val kind = BlockItemType.fromBytes(source);
+        switch (kind) {
+            case ACCOUNT_TRANSACTION:
+                val at = AccountTransaction.fromBytes(source);
+                return new BlockItem(at);
+            case CREDENTIAL_DEPLOYMENT:
+                throw new UnsupportedOperationException("Only account transactions are supported in this version. Credential deployments are not.");
+            case UPDATE_INSTRUCTION:
+                throw new UnsupportedOperationException("Only account transactions are supported in this version. Update instructions are not.");
+            default:
+                throw new UnsupportedOperationException("Unrecognized block item type.");
+        }
+    }
+
+    public static BlockItem fromVersionedBytes(ByteBuffer source) {
+        byte tag = source.get();
+        if (tag == 0) {
+            return BlockItem.fromBytes(source);
+        } else {
+            throw new UnsupportedOperationException("Only block items in version 0 format are supported.");
+        }
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItemType.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/BlockItemType.java
@@ -1,5 +1,11 @@
 package com.concordium.sdk.transactions;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.nio.ByteBuffer;
+
+@ToString
 enum BlockItemType {
     ACCOUNT_TRANSACTION((byte)0),
     CREDENTIAL_DEPLOYMENT((byte)1),
@@ -13,6 +19,16 @@ enum BlockItemType {
 
     byte getByte() {
         return this.value;
+    }
+
+    public static BlockItemType fromBytes(ByteBuffer source) {
+        byte tag = source.get();
+        switch (tag) {
+            case 0: return ACCOUNT_TRANSACTION;
+            case 1: return CREDENTIAL_DEPLOYMENT;
+            case 2: return UPDATE_INSTRUCTION;
+            default: throw new IllegalArgumentException();
+        }
     }
 
     static final int BYTES = 1;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/GTUAmount.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/GTUAmount.java
@@ -3,6 +3,8 @@ package com.concordium.sdk.transactions;
 import com.concordium.sdk.types.UInt64;
 import lombok.Getter;
 
+import java.nio.ByteBuffer;
+
 @Getter
 public class GTUAmount {
     private final UInt64 value;
@@ -23,6 +25,10 @@ public class GTUAmount {
         return value.getBytes();
     }
 
+    public static GTUAmount fromBytes(ByteBuffer source) {
+        UInt64 value = UInt64.fromBytes(source);
+        return new GTUAmount(value);
+    }
     @Override
     public String toString() {
         return value.toString();

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Index.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Index.java
@@ -4,13 +4,15 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.nio.ByteBuffer;
+
 /**
  * The {@link Index} is used when setting up the {@link TransactionSigner} when signing a {@link Transaction}.
  * That is, the {@link Index} serves both as `CredentialIndex` and `KeyIndex`.
  */
 @EqualsAndHashCode
 @ToString
-public class Index {
+public class Index implements Comparable {
     @Getter
     private final byte value;
 
@@ -28,5 +30,27 @@ public class Index {
             throw new IllegalArgumentException("KeyIndex cannot exceed one byte (" + BYTE_MAX_VALUE + ") was " + index);
         }
         return new Index((byte) index);
+    }
+
+    public static Index fromBytes(ByteBuffer source) {
+        return new Index(source.get());
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if (o == null) {
+            throw new NullPointerException();
+        }
+        if (!(o instanceof Index)) {
+            throw new ClassCastException();
+        }
+        Index other = (Index) o;
+        if (this.value < other.value) {
+            return -1;
+        } else if (this.value == other.value) {
+            return 0;
+        } else {
+            return 1;
+        }
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Memo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Memo.java
@@ -2,7 +2,9 @@ package com.concordium.sdk.transactions;
 
 import com.concordium.sdk.exceptions.TransactionCreationException;
 import com.concordium.sdk.types.UInt16;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.val;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
@@ -10,6 +12,8 @@ import org.apache.commons.codec.binary.Hex;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+@EqualsAndHashCode
+@ToString
 public class Memo {
 
     public final static int BYTES = 256;
@@ -35,6 +39,13 @@ public class Memo {
         buffer.put(UInt16.from(value.length).getBytes());
         buffer.put(this.value);
         return buffer.array();
+    }
+
+    public static Memo fromBytes(ByteBuffer source) {
+        val len = UInt16.fromBytes(source);
+        val bytes = new byte[len.getValue()];
+        source.get(bytes);
+        return new Memo(bytes);
     }
 
     // return the length of the serialized memo

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Payload.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Payload.java
@@ -5,11 +5,13 @@ import com.concordium.sdk.exceptions.ED25519Exception;
 import com.concordium.sdk.exceptions.TransactionCreationException;
 import com.concordium.sdk.types.UInt32;
 import com.concordium.sdk.types.UInt64;
+import lombok.EqualsAndHashCode;
 import lombok.val;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+@EqualsAndHashCode
 abstract class Payload {
     TransactionHeader header;
     TransactionSignature signature;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransactionHeader.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransactionHeader.java
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer;
 
 @Getter
 @EqualsAndHashCode
+@ToString
 class TransactionHeader {
     private final AccountAddress sender;
     private final UInt64 accountNonce;
@@ -34,5 +35,17 @@ class TransactionHeader {
         buffer.put(payloadSize.getBytes());
         buffer.put(expiry.getBytes());
         return buffer.array();
+    }
+
+    public static TransactionHeader fromBytes(ByteBuffer source) {
+        AccountAddress sender = AccountAddress.fromBytes(source);
+        UInt64 accountNonce = UInt64.fromBytes(source);
+        UInt64 maxEnergyCost = UInt64.fromBytes(source);
+        UInt32 payloadSize = UInt32.fromBytes(source);
+        UInt64 expiry = UInt64.fromBytes(source);
+        TransactionHeader header = new TransactionHeader(sender, accountNonce, expiry);
+        header.setMaxEnergyCost(maxEnergyCost);
+        header.setPayloadSize(payloadSize);
+        return header;
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Transfer.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Transfer.java
@@ -1,6 +1,7 @@
 package com.concordium.sdk.transactions;
 
 import com.concordium.sdk.types.UInt64;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.val;
@@ -9,6 +10,7 @@ import java.nio.ByteBuffer;
 
 @ToString
 @Getter
+@EqualsAndHashCode
 final class Transfer extends Payload {
 
     private final AccountAddress receiver;
@@ -26,6 +28,12 @@ final class Transfer extends Payload {
         buffer.put(receiver.getBytes());
         buffer.put(amount.getBytes());
         return buffer.array();
+    }
+
+    public static Transfer fromBytes(ByteBuffer source) {
+        val receiver = AccountAddress.fromBytes(source);
+        val amount = GTUAmount.fromBytes(source);
+        return new Transfer(receiver, amount);
     }
 
     @Override

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Transfer.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Transfer.java
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer;
 
 @ToString
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 final class Transfer extends Payload {
 
     private final AccountAddress receiver;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferWithMemo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferWithMemo.java
@@ -1,12 +1,16 @@
 package com.concordium.sdk.transactions;
 
 import com.concordium.sdk.types.UInt64;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 import lombok.val;
 
 import java.nio.ByteBuffer;
 
 @Getter
+@EqualsAndHashCode
+@ToString
 class TransferWithMemo extends Payload {
 
     private final static TransactionType TYPE = TransactionType.TRANSFER_WITH_MEMO;
@@ -37,6 +41,12 @@ class TransferWithMemo extends Payload {
         buffer.put(memo.getBytes());
         buffer.put(getAmount().getValue().getBytes());
         return buffer.array();
+    }
+    public static TransferWithMemo fromBytes(ByteBuffer source) {
+        val receiver = AccountAddress.fromBytes(source);
+        val memo = Memo.fromBytes(source);
+        val amount = GTUAmount.fromBytes(source);
+        return new TransferWithMemo(receiver, amount, memo);
     }
 
     @Override

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferWithMemo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferWithMemo.java
@@ -9,7 +9,7 @@ import lombok.val;
 import java.nio.ByteBuffer;
 
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString
 class TransferWithMemo extends Payload {
 

--- a/concordium-sdk/src/main/java/com/concordium/sdk/types/UInt16.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/types/UInt16.java
@@ -46,4 +46,9 @@ public final class UInt16 {
         return new UInt16(buffer.getShort());
     }
 
+    public static UInt16 fromBytes(ByteBuffer source) {
+        byte[] valueBytes = new byte[2];
+        source.get(valueBytes);
+        return UInt16.from(valueBytes);
+    }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/types/UInt32.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/types/UInt32.java
@@ -40,4 +40,9 @@ public final class UInt32 {
         return new UInt32(buffer.getInt());
     }
 
+    public static UInt32 fromBytes(ByteBuffer source) {
+        byte[] valueBytes = new byte[4];
+        source.get(valueBytes);
+        return UInt32.from(valueBytes);
+    }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/types/UInt64.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/types/UInt64.java
@@ -41,4 +41,10 @@ public final class UInt64 {
         buffer.flip();
         return new UInt64(buffer.getLong());
     }
+
+    public static UInt64 fromBytes(ByteBuffer source) {
+        byte[] valueBytes = new byte[8];
+        source.get(valueBytes);
+        return UInt64.from(valueBytes);
+    }
 }

--- a/concordium-sdk/src/test/java/com/concordium/sdk/transactions/TransferTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/transactions/TransferTest.java
@@ -7,6 +7,8 @@ import lombok.val;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -35,12 +37,12 @@ public class TransferTest {
         assertEquals(41, transfer.getBytes().length);
         assertEquals(601, transfer.header.getMaxEnergyCost().getValue());
         assertEquals("60afc40624ba9c9698efb5f49cae32810bce082b08bd55ca625d63f3e4dd56a2", Hex.encodeHexString(transfer.getDataToSign()));
-
         val blockItem = transfer.toAccountTransaction().toBlockItem();
 
         val blockItemHash = blockItem.getHash();
         assertArrayEquals(TestUtils.EXPECTED_BLOCK_ITEM_BYTES, TestUtils.signedByteArrayToUnsigned(blockItem.getBytes()));
         assertArrayEquals(TestUtils.EXPECTED_BLOCK_ITEM_VERSIONED_BYTES, TestUtils.signedByteArrayToUnsigned(blockItem.getVersionedBytes()));
+        assertEquals(blockItem.getHash(), BlockItem.fromVersionedBytes(ByteBuffer.wrap(blockItem.getVersionedBytes())).getHash());
         assertEquals("6a209eab54720aad71370a6adb4f0661d3606fca25ac544dc0ac0e76e099feba", blockItemHash.asHex());
     }
 }

--- a/concordium-sdk/src/test/java/com/concordium/sdk/transactions/TransferWithMemoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/transactions/TransferWithMemoTest.java
@@ -6,6 +6,8 @@ import com.concordium.sdk.types.UInt64;
 import lombok.val;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+
 import static org.junit.Assert.*;
 
 public class TransferWithMemoTest {
@@ -37,6 +39,7 @@ public class TransferWithMemoTest {
 
             val blockItem = transferWithMemo.toBlockItem();
             assertEquals(Hash.from("2cf00d7d5064ab6f70102a8bba4082b7d85b9b411f981f00b5994adc0b461083"), blockItem.getHash());
+            assertEquals(blockItem.getHash(), BlockItem.fromVersionedBytes(ByteBuffer.wrap(blockItem.getVersionedBytes())).getHash());
             assertArrayEquals(TestUtils.EXPECTED_BLOCK_ITEM_TRANSFER_WITH_MEMO_VERSIONED_BYTES, TestUtils.signedByteArrayToUnsigned(blockItem.getVersionedBytes()));
         } catch (TransactionCreationException e) {
             fail("Unexpected error: " + e.getMessage());


### PR DESCRIPTION
## Purpose

Add inverses to various `getBytes` methods.

## Changes

In addition to deserialization methods, ensure consistent order of key serialization by using an order based map.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
