### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## Unreleased changes
-- Fix parsing bug for `AccountInfo`
-- Transaction `Status` now public
-- `BlockItem` now public
+
+## 1.4.0
+- Fix parsing bug for `AccountInfo` where scheduled releases was not included.
+- Transaction `Status` is now public.
+- `BlockItem` is now public.
 
 ## 1.3.0
 - Support for transaction deserialization.

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->


### PR DESCRIPTION
## Purpose
Release 1.4.0

Fix a parsing bug for `AccountInfo` and made some types public.

## Changes

- Fix parsing bug for `AccountInfo` where scheduled releases was not included.
- Transaction `Status` is now public.
- `BlockItem` is now public.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

