### PR TITLE
AccountTransaction now exposes `getType` for the payload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- `AccountTransaction` now exposes a `getType` function which
+   returns the type of the underlying `Payload`.
 
 ## 1.5.0
 - Exposed more of the `transactions` in the API.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
@@ -32,6 +32,15 @@ public final class AccountTransaction {
         return buffer.array();
     }
 
+    /**
+     * Returns the type of the {@link Payload} associated
+     * with this `AccountTransaction`.
+     * @return the {@link com.concordium.sdk.transactions.Payload.PayloadType}
+     */
+    public Payload.PayloadType getType() {
+        return this.payload.getType();
+    }
+
     BlockItem toBlockItem() {
         return BlockItem.from(this);
     }
@@ -53,4 +62,5 @@ public final class AccountTransaction {
         }
         return new AccountTransaction(signature, header, payload);
     }
+
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountTransaction.java
@@ -62,5 +62,4 @@ public final class AccountTransaction {
         }
         return new AccountTransaction(signature, header, payload);
     }
-
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Payload.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Payload.java
@@ -12,20 +12,28 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 
 @EqualsAndHashCode
-abstract class Payload {
+public abstract class Payload {
     TransactionHeader header;
     TransactionSignature signature;
+
+    PayloadType type;
 
     BlockItem toBlockItem() {
         return BlockItem.from(new AccountTransaction(signature, header, this));
     }
+
+    /**
+     * Get the {@link PayloadType}
+     * @return the type of the {@link Payload}
+     */
+    public abstract PayloadType getType();
 
     abstract byte[] getBytes();
 
     abstract UInt64 getTransactionTypeCost();
 
     final AccountTransaction toAccountTransaction() {
-        return new AccountTransaction(signature, header, this);
+        return new AccountTransaction(signature, header,this);
     }
 
     final Payload withHeader(TransactionHeader header) {
@@ -78,6 +86,11 @@ abstract class Payload {
                 CONSTANT_A * noOfSignatures +
                 CONSTANT_B * (TRANSACTION_HEADER_SIZE + payloadSize)
                 + transactionSpecificCost.getValue());
+    }
+
+    public enum PayloadType {
+        TRANSFER,
+        TRANSFER_WITH_MEMO
     }
 
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Payload.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Payload.java
@@ -33,7 +33,7 @@ public abstract class Payload {
     abstract UInt64 getTransactionTypeCost();
 
     final AccountTransaction toAccountTransaction() {
-        return new AccountTransaction(signature, header,this);
+        return new AccountTransaction(signature, header, this);
     }
 
     final Payload withHeader(TransactionHeader header) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Transfer.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Transfer.java
@@ -22,6 +22,11 @@ public final class Transfer extends Payload {
     }
 
     @Override
+    public PayloadType getType() {
+        return PayloadType.TRANSFER;
+    }
+
+    @Override
     byte[] getBytes() {
         val buffer = ByteBuffer.allocate(TransactionType.BYTES + AccountAddress.BYTES + UInt64.BYTES);
         buffer.put(TransactionType.SIMPLE_TRANSFER.getValue());

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferTransaction.java
@@ -37,7 +37,7 @@ public class TransferTransaction extends AbstractTransaction {
     }
 
     @Override
-    BlockItem getBlockItem() {
+    public BlockItem getBlockItem() {
         return blockItem;
     }
 

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferWithMemo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferWithMemo.java
@@ -30,6 +30,11 @@ public class TransferWithMemo extends Payload {
     }
 
     @Override
+    public PayloadType getType() {
+        return PayloadType.TRANSFER_WITH_MEMO;
+    }
+
+    @Override
     byte[] getBytes() {
         val buffer = ByteBuffer.allocate(
                 TransactionType.BYTES +


### PR DESCRIPTION
## Purpose

When deconstructing a `BlockItem` it is useful to know the type of the underlying `Payload` in advance.

## Changes

Exposed `Payload.PayloadType getType` for `AccountTransaction`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

