### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+
+## 1.6.0
 - `AccountTransaction` now exposes a `getType` function which
    returns the type of the underlying `Payload`.
 

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->


### PR DESCRIPTION
## Purpose

Release 1.6.0

- `AccountTransaction` now exposes a `getType` function which
   returns the type of the underlying `Payload`.

## Changes

Extended `AcccountTransaction` with a `getType` method. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

