### PR TITLE
Fix bug where timeout was not correctly set for the `Client`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Fix a bug which caused the Client to have a global absolute timeout from when it was initialized.
+
 
 ## 1.6.0
 - `AccountTransaction` now exposes a `getType` function which

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
@@ -7,12 +7,29 @@ import lombok.val;
 
 import java.util.Objects;
 
+/**
+ * Connection properties
+ */
 @Getter
 public final class Connection {
+    /**
+     * The host to connect to.
+     */
     private final String host;
+    /**
+     * The port to use.
+     */
     private final int port;
+    /**
+     * The timeout for each request (in milliseconds).
+     * The default timeout is 15000 milliseconds if a non-positive value is supplied then
+     * the default value will be used.
+     */
     private int timeout;
 
+    /**
+     * The gRPC `Authentication` token.
+     */
     private final Credentials credentials;
 
     @Builder
@@ -41,7 +58,7 @@ public final class Connection {
                 throw new IllegalArgumentException("Connection credentials cannot be null");
             }
             // setting a default timeout of 15 000 ms
-            if (connection.timeout == 0) {
+            if (connection.timeout < 1) {
                 connection.timeout = DEFAULT_TIMEOUT_MS;
             }
             return connection;


### PR DESCRIPTION
## Purpose

Fix  a bug which caused the `Client` to have a _global_ absolute timeout from when it was initialized. 

## Changes

The client now correctly sets a timeout for each request. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

