### PR TITLE
Added the possibillity for providing custom http headers for the grpc connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Allow consumers to provide extra HTTP headers for the gRPC connection.
 
 ## 1.6.1
 - Fix a bug which caused the `Client` to use a global absolute timeout from when it was initialized.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Connection connection = Connection.builder()
                 .build();
 Client client = Client.from(connection);
 ```
+One can also provide extra HTTP headers to the grpc calls by setting up the client as the following:
+
+Connection connection = Connection.builder()
+                .credentials(Credentials.builder()
+                        .authenticationToken(${password})
+                        .withAdditionalHeader(Header.from("HEADER1", "VALUE1"))
+                        .withAdditionalHeader(Header.from("HEADER2", "VALUE2"))
+                        .build())
+                .host(${node_url})
+                .port(${node_port})
+                .timeout(${timeout})
+                .build();
+Client client = Client.from(connection);
+
+Note. One cannot provide an additional `Header` 'Authentication' as this is already used for the ${password}.
+
 where
 
 - `password` is the password to use

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Client client = Client.from(connection);
 ```
 One can also provide extra HTTP headers to the grpc calls by setting up the client as the following:
 
+```java
 Connection connection = Connection.builder()
                 .credentials(Credentials.builder()
                         .authenticationToken(${password})
@@ -97,6 +98,7 @@ Connection connection = Connection.builder()
                 .timeout(${timeout})
                 .build();
 Client client = Client.from(connection);
+```
 
 Note. One cannot provide an additional `Header` 'Authentication' as this is already used for the ${password}.
 

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
@@ -1,11 +1,15 @@
 package com.concordium.sdk;
 
 
+import com.google.common.collect.Sets;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.val;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Connection properties

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Credentials.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Credentials.java
@@ -2,12 +2,15 @@ package com.concordium.sdk;
 
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
-import lombok.Getter;
-import lombok.val;
+import lombok.*;
 
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 @Getter
+@Setter
 public class Credentials extends CallCredentials {
     private final CallCredentials callCredentials;
 
@@ -15,9 +18,21 @@ public class Credentials extends CallCredentials {
         this.callCredentials = credentials;
     }
 
-    public static Credentials from(String username) {
-        val callCredential = new CallCredentials(username);
+    public static Credentials from(String authenticationToken) {
+        val callCredential = new CallCredentials(authenticationToken);
         return new Credentials(callCredential);
+    }
+
+    /**
+     * Create a {@link Credentials} object with additional headers to be used
+     * within the underlying gRPC connection.
+     *
+     * @param authenticationToken   the authentication token i.e., the header 'Authentication' is set with this value.
+     * @param withAdditionalHeaders an optional set of extra headers to use within the connection.
+     */
+    @Builder
+    public Credentials(String authenticationToken, @Singular Set<Header> withAdditionalHeaders) {
+        this.callCredentials = new CallCredentials(authenticationToken, withAdditionalHeaders);
     }
 
     @Override
@@ -30,20 +45,51 @@ public class Credentials extends CallCredentials {
         this.callCredentials.thisUsesUnstableApi();
     }
 
+
     private static final class CallCredentials extends io.grpc.CallCredentials {
-        private final String username;
+        private final String authenticationToken;
+        private final Set<Header> additionalHeaders;
 
-        private final Metadata.Key<String> META_DATA_KEY = Metadata.Key.of(("Authentication"), Metadata.ASCII_STRING_MARSHALLER);
+        private Metadata cachedMetadata;
 
-        CallCredentials(final String username) {
-            this.username = username;
+        private final Metadata.Key<String> META_DATA_KEY = Metadata.Key.of((Header.AUTHENTICATION_HEADER), Metadata.ASCII_STRING_MARSHALLER);
+
+        CallCredentials(final String authenticationToken) {
+            this.authenticationToken = authenticationToken;
+            this.additionalHeaders = Collections.emptySet();
+        }
+
+        CallCredentials(final String authenticationToken, final Set<Header> additionalHeaders) {
+            this.authenticationToken = authenticationToken;
+            this.additionalHeaders = additionalHeaders;
         }
 
         @Override
         public void applyRequestMetadata(RequestInfo requestInfo, Executor executor, MetadataApplier metadataApplier) {
-            Metadata metadata = new Metadata();
-            metadata.put(META_DATA_KEY, this.username);
-            metadataApplier.apply(metadata);
+            metadataApplier.apply(getMetadata());
+        }
+
+        private Metadata getMetadata() {
+            if (Objects.isNull(this.cachedMetadata)) {
+                this.cachedMetadata = createMetadata();
+            }
+            return this.cachedMetadata;
+        }
+
+        private Metadata createMetadata() {
+            val metadata = new Metadata();
+            if (!Objects.isNull(authenticationToken)) {
+                metadata.put(META_DATA_KEY, this.authenticationToken);
+            }
+            for (Header header : additionalHeaders) {
+                addHeader(metadata, header);
+            }
+            return metadata;
+        }
+
+        private void addHeader(Metadata metadata, Header header) {
+            Metadata.Key<String> key = Metadata.Key.of(header.getKey(), Metadata.ASCII_STRING_MARSHALLER);
+            metadata.put(key, header.getValue());
         }
 
         @Override

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Credentials.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Credentials.java
@@ -52,7 +52,7 @@ public class Credentials extends CallCredentials {
 
         private Metadata cachedMetadata;
 
-        private final Metadata.Key<String> META_DATA_KEY = Metadata.Key.of((Header.AUTHENTICATION_HEADER), Metadata.ASCII_STRING_MARSHALLER);
+        private final Metadata.Key<String> AUTHENTICATION_META_DATA_KEY = Metadata.Key.of((Header.AUTHENTICATION_HEADER), Metadata.ASCII_STRING_MARSHALLER);
 
         CallCredentials(final String authenticationToken) {
             this.authenticationToken = authenticationToken;
@@ -79,7 +79,7 @@ public class Credentials extends CallCredentials {
         private Metadata createMetadata() {
             val metadata = new Metadata();
             if (!Objects.isNull(authenticationToken)) {
-                metadata.put(META_DATA_KEY, this.authenticationToken);
+                metadata.put(AUTHENTICATION_META_DATA_KEY, this.authenticationToken);
             }
             for (Header header : additionalHeaders) {
                 addHeader(metadata, header);

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Header.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Header.java
@@ -1,0 +1,34 @@
+package com.concordium.sdk;
+
+import lombok.Getter;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An HTTP header {@link Connection} for the underlying gRPC connection.
+ * Note. The header {@link Header#AUTHENTICATION_HEADER} is reserved.
+ * To set the value of this `Authentication` header use {@link Credentials#from(String)} or {@link Credentials#Credentials(String, Set)}.
+ */
+@Getter
+public class Header {
+    private final String key;
+    private final String value;
+
+    private Header(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public static Header from(String header, String value) {
+        if (Objects.isNull(header) || Objects.isNull(value)) {
+            throw new IllegalArgumentException("Header or value must be non-null.");
+        }
+        if (header.equals(AUTHENTICATION_HEADER)) {
+            throw new IllegalArgumentException(AUTHENTICATION_HEADER + " header is reserved");
+        }
+        return new Header(header, value);
+    }
+
+    public static String AUTHENTICATION_HEADER = "Authentication";
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/TransactionContents.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/TransactionContents.java
@@ -76,5 +76,5 @@ enum TransactionContents {
     @JsonProperty("addIdentityProvider")
     ADD_IDENTITY_PROVIDER,
     @JsonProperty("updateAddIdentityProvider")
-    UPDATE_ADD_IDENTITY_PROVIDER;
+    UPDATE_ADD_IDENTITY_PROVIDER
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/UpdateType.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/UpdateType.java
@@ -30,5 +30,5 @@ enum UpdateType {
     @JsonProperty("addAnonymityRevoker")
     ADD_ANONYMITY_REVOKER,
     @JsonProperty("addIdentityProvider")
-    ADD_IDENTITY_PROVIDER;
+    ADD_IDENTITY_PROVIDER
 }


### PR DESCRIPTION
## Purpose

Provide the user with the option of providing additional http headers for the grpc connection.

## Changes

Introduced a `Header` type  and a new `Credentials.builder()` which supports the option of providing more http headers. 

Example usage: 

```
                         Credentials.builder()
                        .authenticationToken("rpcadmin")
                        .withAdditionalHeader(Header.from("foo", "bar"))
                        .withAdditionalHeader(Header.from("baz", "qux"))
                        .build()
```

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
