### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+## 1.7.0
 - Allow consumers to provide extra HTTP headers for the gRPC connection.
 
 ## 1.6.1

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.7.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->


### PR DESCRIPTION
## Purpose
Release 1.7.0

- Allow consumers to provide extra HTTP headers for the gRPC connection.

## Changes

Updated the `pom.xml` and `CHANGELOG.md` with the new changes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
