### PR TITLE
Support for configuring TLS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+- Support for configuring TLS.
+  (Note for release - this breaks API because initialization of the client can now 
+  throw a `ClientInitializationException`.)
 
 ## 1.7.0
 - Allow consumers to provide extra HTTP headers for the gRPC connection.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Connection connection = Connection.builder()
                 .build();
 Client client = Client.from(connection);
 ```
+
+where
+
+- `password` is the password to use
+- `node_url`  is the url of the node
+- `node_port` is the nodes rpc port
+- `timeout` is the timeout for the GRPC connection (default is 15000 ms)
+
+### Configuring the connection
+
 One can also provide extra HTTP headers to the grpc calls by setting up the client as the following:
 
 ```java
@@ -102,12 +112,25 @@ Client client = Client.from(connection);
 
 Note. One cannot provide an additional `Header` 'Authentication' as this is already used for the ${password}.
 
-where
+#### Enforcing TLS
 
-- `password` is the password to use
-- `node_url`  is the url of the node
-- `node_port` is the nodes rpc port
-- `timeout` is the timeout for the GRPC connection (default is 15000 ms)
+It is also possible to enforce TLS to be used in the underlying connection e.g.
+
+```java
+Connection connection = Connection.builder()
+                .credentials(Credentials.builder()
+                        .authenticationToken(${password})
+                        .withAdditionalHeader(Header.from("HEADER1", "VALUE1"))
+                        .withAdditionalHeader(Header.from("HEADER2", "VALUE2"))
+                        .build())
+                .host(${node_url})
+                .port(${node_port})
+                .timeout(${timeout})
+                .useTLS(TLSConfig.from(new File("/a/path/to/the/servers/certificate.pem")))
+                .build();
+Client client = Client.from(connection);
+```
+
 
 Further the `Client` exposes a `close()` function which should be called when finished using the client in order to
 perform an orderly shutdown of the underlying grpc connection.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
@@ -1,7 +1,6 @@
 package com.concordium.sdk;
 
 
-import com.sun.istack.internal.NotNull;
 import io.grpc.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -124,7 +123,7 @@ public final class Connection {
         return channel;
     }
 
-    private ChannelCredentials getTLSChannel(@NotNull TLSConfig tlsConfig) throws IOException {
+    private ChannelCredentials getTLSChannel(TLSConfig tlsConfig) throws IOException {
         if (Objects.isNull(tlsConfig.getServerCert())) {
             return TlsChannelCredentials.create();
         }else {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
@@ -128,7 +128,7 @@ public final class Connection {
             return TlsChannelCredentials.create();
         }else {
             val builder = TlsChannelCredentials.newBuilder();
-            if(!Objects.isNull(tlsConfig.getClientCert())) {
+            if(!Objects.isNull(tlsConfig.getServerCert())) {
                 builder.trustManager(tlsConfig.getServerCert());
             }
             if (getTlsConfig().isMTLS()) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/Connection.java
@@ -1,15 +1,14 @@
 package com.concordium.sdk;
 
 
-import com.google.common.collect.Sets;
+import com.sun.istack.internal.NotNull;
+import io.grpc.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.val;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.io.IOException;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Connection properties
@@ -36,12 +35,43 @@ public final class Connection {
      */
     private final Credentials credentials;
 
+    /**
+     * The {@link TLSConfig} to use.
+     * If this is not set i.e. 'null' then the underlying HTTP connection can fall back to 'plain-text'
+     * if the servers certificate cannot be verified against the standard CA root.
+     * <p>
+     * Otherwise, if this is set then the connection will use the supplied {@link TLSConfig} for
+     * setting up trust and possibly mTLS. See {@link TLSConfig} for more configuration details.
+     */
+    private final TLSConfig tlsConfig;
+
+    /**
+     * Create a {@link Connection}
+     *
+     * @param host        the host to connect to.
+     * @param port        the port to use.
+     * @param timeout     the timeout for each request.
+     * @param credentials The {@link Credentials} to use for the connection.
+     *                    This includes the 'Authentication' header and
+     *                    possibly additional HTTP headers.
+     * @param useTLS      Whether to enforce the usage of TLS and use the specified TLS configuration.
+     */
     @Builder
-    public Connection(String host, int port, int timeout, Credentials credentials) {
+    public Connection(String host, int port, int timeout, Credentials credentials, TLSConfig useTLS) {
         this.host = host;
         this.port = port;
         this.timeout = timeout;
         this.credentials = credentials;
+        this.tlsConfig = useTLS;
+    }
+
+    /**
+     * Whether to enforce TLS or not.
+     *
+     * @return true if TLS must be used for the underlying connection.
+     */
+    boolean enforceTLS() {
+        return !Objects.isNull(tlsConfig);
     }
 
     public static Connection.ConnectionBuilder builder() {
@@ -65,8 +95,49 @@ public final class Connection {
             if (connection.timeout < 1) {
                 connection.timeout = DEFAULT_TIMEOUT_MS;
             }
+            // throws an `IllegalArgumentException` if the configuration is
+            // deemed invalid.
+            if (connection.enforceTLS()) {
+                connection.getTlsConfig().assertOk();
+            }
             return connection;
         }
+    }
+
+    /**
+     * Create the channel to be used based on the {@link Connection} configuration.
+     *
+     * @return a new {@link ManagedChannel}
+     */
+    ManagedChannel newChannel() throws IOException {
+        ManagedChannel channel;
+        if (enforceTLS()) {
+            val tlsConfig = getTlsConfig();
+            ChannelCredentials tlsChannel = getTLSChannel(tlsConfig);
+            return Grpc.newChannelBuilderForAddress(getHost(), getPort(), tlsChannel).build();
+        } else {
+            channel = ManagedChannelBuilder.
+                    forAddress(getHost(), getPort())
+                    .usePlaintext()
+                    .build();
+        }
+        return channel;
+    }
+
+    private ChannelCredentials getTLSChannel(@NotNull TLSConfig tlsConfig) throws IOException {
+        if (Objects.isNull(tlsConfig.getServerCert())) {
+            return TlsChannelCredentials.create();
+        }else {
+            val builder = TlsChannelCredentials.newBuilder();
+            if(!Objects.isNull(tlsConfig.getClientCert())) {
+                builder.trustManager(tlsConfig.getServerCert());
+            }
+            if (getTlsConfig().isMTLS()) {
+                builder.keyManager(tlsConfig.getClientCert(), tlsConfig.getClientKeyFile());
+            }
+            return builder.build();
+        }
+
     }
 
     private static final int DEFAULT_TIMEOUT_MS = 15000;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/TLSConfig.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/TLSConfig.java
@@ -1,6 +1,5 @@
 package com.concordium.sdk;
 
-import com.sun.istack.internal.NotNull;
 import io.grpc.TlsChannelCredentials;
 import lombok.Getter;
 import lombok.val;
@@ -61,7 +60,7 @@ public class TLSConfig {
      * @param clientKeyFile The PEM encoded PKCS#8 private key for the client.
      * @return the TLSConfig
      */
-    public static TLSConfig mTLS(File serverCert, @NotNull File clientCert, @NotNull File clientKeyFile) {
+    public static TLSConfig mTLS(File serverCert, File clientCert, File clientKeyFile) {
         val tlsConfig = new TLSConfig(serverCert);
         tlsConfig.clientCert = clientCert;
         tlsConfig.clientKeyFile = clientKeyFile;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/TLSConfig.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/TLSConfig.java
@@ -1,0 +1,91 @@
+package com.concordium.sdk;
+
+import com.sun.istack.internal.NotNull;
+import io.grpc.TlsChannelCredentials;
+import lombok.Getter;
+import lombok.val;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * Configuration to be used for a TLS enforced {@link Connection}
+ */
+@Getter
+public class TLSConfig {
+    /**
+     * The servers certificate or some CA that authorized it.
+     * See {@link TlsChannelCredentials.Builder#trustManager(File)} for details of the
+     * expected file format.
+     */
+    private final File serverCert;
+
+    /**
+     * If mTLS is to be used then this should be set to the
+     * certificate of the client.
+     * See {@link TlsChannelCredentials.Builder#keyManager(File, File)} for details of the
+     * expected file format.
+     */
+    private File clientCert;
+    /**
+     * If mTLS is to be used then this should be set to the
+     * private key of the client.
+     * See {@link TlsChannelCredentials.Builder#keyManager(File, File)} for details of the
+     * expected file format.
+     */
+    private File clientKeyFile;
+
+    boolean isMTLS() {
+        return !Objects.isNull(clientCert);
+    }
+
+    private TLSConfig(File serverCert) {
+        this.serverCert = serverCert;
+    }
+
+    /**
+     * Constructor for establishing a basic TLS connection.
+     * @param serverCert The X509 certificate of the server.
+     * @return the TLSConfig
+     */
+    public static TLSConfig from(File serverCert) {
+        return new TLSConfig(serverCert);
+    }
+
+    /**
+     * Constructor for establishing a mTLS connection.
+     * @param serverCert The pem encoded certificate of the server.
+     *                   Supply 'null' here if the default JVM trust store should
+     *                   be used for the connection.
+     * @param clientCert The pem encoded certificate of the client
+     * @param clientKeyFile The PEM encoded PKCS#8 private key for the client.
+     * @return the TLSConfig
+     */
+    public static TLSConfig mTLS(File serverCert, @NotNull File clientCert, @NotNull File clientKeyFile) {
+        val tlsConfig = new TLSConfig(serverCert);
+        tlsConfig.clientCert = clientCert;
+        tlsConfig.clientKeyFile = clientKeyFile;
+        return tlsConfig;
+    }
+
+    /**
+     * The underlying connection is forced to use TLS.
+     * Note. the servers certificate must be trusted by the default jks CA.
+     *
+     * See {@link TLSConfig#from(File)} or {@link TLSConfig#mTLS(File, File, File)} for configuring
+     * custom trust or mTLS.
+     * @return the TLSConfig
+     */
+    public static TLSConfig auto() {
+        return new TLSConfig(null);
+    }
+
+    public void assertOk() {
+        if (Objects.isNull(this.clientCert) && !Objects.isNull(this.clientKeyFile)) {
+            throw new IllegalArgumentException("mTLS was configured. But a client key certificate was missing.");
+        }
+        if (!Objects.isNull(this.clientCert) && Objects.isNull(this.clientKeyFile)) {
+            throw new IllegalArgumentException("mTLS was configured. But a client key file was missing.");
+        }
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/exceptions/ClientInitializationException.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/exceptions/ClientInitializationException.java
@@ -1,0 +1,25 @@
+package com.concordium.sdk.exceptions;
+
+import lombok.Getter;
+
+import java.io.IOException;
+
+/**
+ * Wrapper for checked exceptions that can occur when creating a {@link com.concordium.sdk.Client}.
+ */
+public class ClientInitializationException extends Exception {
+    /**
+     * The root cause
+     */
+    @Getter
+    private final Exception inner;
+
+     private ClientInitializationException(Exception inner) {
+        super("The Client could not be constructed. " + inner.getMessage());
+        this.inner = inner;
+    }
+
+    public static ClientInitializationException from(IOException e) {
+        return new ClientInitializationException(e);
+    }
+}


### PR DESCRIPTION
## Purpose

Support for configuring TLS, mTLS etc.

## Changes

Introduced a `TLSConfig` type which can be used together with `Connection` for configuring TLS. 

Variants supported:

- 'auto' - will use the default jvm trust store. 
- 'custom' - TLS where the servers certificate or a CA authorizing it can be provided. 
- 'mTLS' - mutual TLS where the client is also provided with a certificate and a private key.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

