### PR TITLE
Upgrade lombok to 1.18.24

### DIFF
--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose

Fix a compilation error when using the @Singular annotation provided by Lombok and maven 3.8.1. 

## Changes

Update the lombok dependency from 1.18.20 to 1.18.24

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
