### PR TITLE
Support for creating account address from regid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased changes
-- CredentialRegistrationID type added and AccountAddress can be derived from it.
+
+## 2.1.0
+- CredentialRegistrationID type introduced and AccountAddress can be derived from it.
 
 ## 2.0.0
 - Support for configuring TLS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- CredentialRegistrationID type added and AccountAddress can be derived from it.
 
 ## 2.0.0
 - Support for configuring TLS.

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
@@ -49,6 +49,7 @@ public final class AccountAddress {
      * Create a {@link AccountAddress} from a {@link CredentialRegistrationId}.
      * @param regId the credential registration id to derive the {@link AccountAddress} from
      * @return the derived {@link AccountAddress}
+     * Note that this is only valid if the account was created via a credential with the given credential registration ID. That is, the derived address will only be correct for the account if the credential is the first credential on the account.
      */
     public static AccountAddress from(CredentialRegistrationId regId) {
         return AccountAddress.from(SHA256.hash(regId.getRegId()));

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/AccountAddress.java
@@ -1,5 +1,6 @@
 package com.concordium.sdk.transactions;
 
+import com.concordium.sdk.crypto.SHA256;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -42,6 +43,15 @@ public final class AccountAddress {
     public static AccountAddress from(String address) {
         val addressBytes = Base58.decodeChecked(VERSION, address);
         return AccountAddress.from(addressBytes);
+    }
+
+    /**
+     * Create a {@link AccountAddress} from a {@link CredentialRegistrationId}.
+     * @param regId the credential registration id to derive the {@link AccountAddress} from
+     * @return the derived {@link AccountAddress}
+     */
+    public static AccountAddress from(CredentialRegistrationId regId) {
+        return AccountAddress.from(SHA256.hash(regId.getRegId()));
     }
 
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
@@ -1,0 +1,38 @@
+package com.concordium.sdk.transactions;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.ToString;
+import org.apache.commons.codec.binary.Hex;
+
+/**
+ * A credential registration id
+ */
+@ToString
+@EqualsAndHashCode
+public class CredentialRegistrationId {
+    @Getter
+    private final byte[] regId;
+
+    private CredentialRegistrationId(byte[] regId) {
+        this.regId = regId;
+    }
+
+    /**
+     * Create a {@link CredentialRegistrationId} from the hex encoded registration id.
+     */
+    @SneakyThrows
+    public static CredentialRegistrationId from(String encoded) {
+        return new CredentialRegistrationId(Hex.decodeHex(encoded));
+    }
+
+    /**
+     * Create a {@link CredentialRegistrationId} from raw bytes
+     * @param bytes the credential registration id bytes
+     * @return a {@link CredentialRegistrationId}
+     */
+    public static CredentialRegistrationId fromBytes(byte[] bytes) {
+        return new CredentialRegistrationId(bytes);
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
@@ -36,6 +36,13 @@ public class CredentialRegistrationId {
     /**
      * Create a {@link CredentialRegistrationId} from raw bytes
      *
+     * Note. This is not the most optimal check as in fact the credential registration id
+     * is a group element in the G1 curve of the BLS pairing.
+     * Hence, not every series of bytes (with the correct size) is a valid credential registration id.
+     *
+     * Maintainer note. A future implementation could make use of the above comment and
+     * provide stronger verification of the credential registration id.
+     *
      * @param bytes the credential registration id bytes
      * @return a {@link CredentialRegistrationId}
      */

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
@@ -1,10 +1,10 @@
 package com.concordium.sdk.transactions;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.SneakyThrows;
-import lombok.ToString;
+import lombok.*;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+
+import java.util.Objects;
 
 /**
  * A credential registration id
@@ -12,6 +12,8 @@ import org.apache.commons.codec.binary.Hex;
 @ToString
 @EqualsAndHashCode
 public class CredentialRegistrationId {
+    //the length of `CredentialRegistrationId` bytes
+    private static final int LENGTH = 48;
     @Getter
     private final byte[] regId;
 
@@ -22,9 +24,13 @@ public class CredentialRegistrationId {
     /**
      * Create a {@link CredentialRegistrationId} from the hex encoded registration id.
      */
-    @SneakyThrows
     public static CredentialRegistrationId from(String encoded) {
-        return new CredentialRegistrationId(Hex.decodeHex(encoded));
+        try {
+            val regId = Hex.decodeHex(encoded);
+            return CredentialRegistrationId.fromBytes(regId);
+        } catch (DecoderException e) {
+            throw new IllegalArgumentException("CredentialRegistrationId is not a valid HEX encoding", e);
+        }
     }
 
     /**
@@ -34,6 +40,10 @@ public class CredentialRegistrationId {
      * @return a {@link CredentialRegistrationId}
      */
     public static CredentialRegistrationId fromBytes(byte[] bytes) {
+        if (bytes.length != LENGTH) {
+            throw new IllegalArgumentException("Unexpected CredentialRegistrationId bytes length. " +
+                    "Expected " + LENGTH + " but was " + bytes.length);
+        }
         return new CredentialRegistrationId(bytes);
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialRegistrationId.java
@@ -29,6 +29,7 @@ public class CredentialRegistrationId {
 
     /**
      * Create a {@link CredentialRegistrationId} from raw bytes
+     *
      * @param bytes the credential registration id bytes
      * @return a {@link CredentialRegistrationId}
      */

--- a/concordium-sdk/src/test/java/com/concordium/sdk/transactions/AccountAddressTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/transactions/AccountAddressTest.java
@@ -64,4 +64,11 @@ public class AccountAddressTest {
             }
         }
     }
+
+    @Test
+    public void testCreateAccountAddressFromCredentialRegistrationId() {
+        val regId = CredentialRegistrationId.from("8e37800e11cdaa6b6e281e284ce3d0021935adb0bec6c9e987ae9bc1880668ea75b9a487b4318badda6763d21aa25f56");
+        val address = AccountAddress.from(regId);
+        assertEquals("3o1oLidRY8wnRDMB2gAjxC5MswVYammyw4WG5i64j89ce7o3cs", address.encoded());
+    }
 }

--- a/concordium-sdk/src/test/java/com/concordium/sdk/transactions/AccountAddressTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/transactions/AccountAddressTest.java
@@ -67,8 +67,8 @@ public class AccountAddressTest {
 
     @Test
     public void testCreateAccountAddressFromCredentialRegistrationId() {
-        val regId = CredentialRegistrationId.from("8e37800e11cdaa6b6e281e284ce3d0021935adb0bec6c9e987ae9bc1880668ea75b9a487b4318badda6763d21aa25f56");
+        val regId = CredentialRegistrationId.from("8e5c75fda3f791efd025e7e8fb0c26c3e111211e375fc9423b1ca308a696140e44c90dcabe75108b41db625152acae50");
         val address = AccountAddress.from(regId);
-        assertEquals("3o1oLidRY8wnRDMB2gAjxC5MswVYammyw4WG5i64j89ce7o3cs", address.encoded());
+        assertEquals("4LYFWsgZvL6bXC5edMgy7SpPg7BV7qK2TcPQRq3YZP9YgShrSQ", address.encoded());
     }
 }


### PR DESCRIPTION
## Purpose

Support for creating an `AccountAddress` from the credential registration id. 

## Changes

- new type `CredentialRegistrationId`
- AccountAddress.from(CredentialRegistrationID) added

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

