### PR TITLE
UpdateEnqueuedResult now parses `effectiveTime` in seconds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased changes
 
-## 3.0.1
-- Fixed bug in `UpdateEnqueuedResult` which parsed `effectiveTime` wrong.
+- Fixed bug in `UpdateEnqueuedResult` which parsed `effectiveTime` in wrong.
 
 ## 3.0.0
 - Stronger typing for various places in the API. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+## 3.0.1
+- Fixed bug in `UpdateEnqueuedResult` which parsed `effectiveTime` wrong.
+
 ## 3.0.0
 - Stronger typing for various places in the API. 
 - Renamed GTUAmount to CCDAmount

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blocksummary/updates/queues/EnqueuedUpdate.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blocksummary/updates/queues/EnqueuedUpdate.java
@@ -1,17 +1,13 @@
 package com.concordium.sdk.responses.blocksummary.updates.queues;
 
 import com.concordium.sdk.types.Nonce;
-import com.concordium.sdk.types.Timestamp;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.val;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A wrapper around an enqueued update containing the 'nextSequenceNumber' and an enqueued update.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/UpdateEnqueuedResult.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/transactionstatus/UpdateEnqueuedResult.java
@@ -17,10 +17,9 @@ public final class UpdateEnqueuedResult extends TransactionResultEvent {
 
     @JsonCreator
     UpdateEnqueuedResult(@JsonProperty("payload") UpdateEnqueuedPayloadResult<Object> payload,
-                         @JsonProperty("effectiveTime") Timestamp effectiveTime) {
-
+                         @JsonProperty("effectiveTime") long effectiveTime) {
         this.payload = payload;
-        this.effectiveTime = effectiveTime;
+        this.effectiveTime = Timestamp.newSeconds(effectiveTime);
     }
 
     @Override


### PR DESCRIPTION
## Purpose

`UpdateEnqueuedResult` parsed the `effectiveTime` wrongly. It interpreted the timestamp in milliseconds instead of seconds.

## Changes

Fix the bug by now parsing `effectiveTime` in seconds. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
