### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## Unreleased changes
+
+## 4.0.0
+- Support for Protocol 5.
 - Added support for initializing smart contracts.
 - Added support for Update Contract.
 - Added support for Deploy Module transaction.
-- Support for P5
 - Fix a bug where pending changes for delegators were not visible via `getAccountInfo`.
 - Removed `BlocksAtHeightRequest.newRelative(long height, ProtocolVersion protocolVersion, boolean restrictedToGenesisIndex)`
   as it was only a valid call on `mainnet` as all protocols exists there. However this may not be true on e.g. `testnet`.

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>4.0.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->


### PR DESCRIPTION
## Purpose

Release 4.0.0 of the Concordium java sdk. 

See CHANGELOG for details. 

But in particular this supports the upcoming protocol 5 on the concordium network. 

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

