### PR TITLE
DRAFT: Fix mac M1/M2 chip build

### DIFF
--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -95,6 +95,94 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>mac-os</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.xolstice.maven.plugins</groupId>
+                        <artifactId>protobuf-maven-plugin</artifactId>
+                        <version>0.6.1</version>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:3.17.3:exe:osx-x86_64</protocArtifact>
+                            <pluginId>grpc-java</pluginId>
+                            <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.40.1:exe:osx-x86_64</pluginArtifact>
+                            <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
+                            <protoSourceRoot>${project.basedir}/../concordium-base/concordium-grpc-api/</protoSourceRoot>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compile</goal>
+                                    <goal>compile-custom</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+
+            </build>
+        </profile>
+        <profile>
+            <id>other-os</id>
+            <activation>
+                <os>
+                    <family>!mac</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.xolstice.maven.plugins</groupId>
+                        <artifactId>protobuf-maven-plugin</artifactId>
+                        <version>0.6.1</version>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:3.17.3:exe:${os.detected.classifier}</protocArtifact>
+                            <pluginId>grpc-java</pluginId>
+                            <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.40.1:exe:${os.detected.classifier}</pluginArtifact>
+                            <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
+                            <protoSourceRoot>${project.basedir}/../concordium-base/concordium-grpc-api/</protoSourceRoot>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compile</goal>
+                                    <goal>compile-custom</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <extensions>
             <extension>
@@ -103,38 +191,6 @@
                 <version>1.6.2</version>
             </extension>
         </extensions>
-        <plugins>
-            <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
-                <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.17.3:exe:${os.detected.classifier}</protocArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.40.1:exe:${os.detected.classifier}</pluginArtifact>
-                    <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
-                    <protoSourceRoot>${project.basedir}/../concordium-base/concordium-grpc-api/</protoSourceRoot>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>compile-custom</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
-        </plugins>
         <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
             <plugins>
                 <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->


### PR DESCRIPTION
## Purpose

Fix mac M1/M2 chip build. 
Two issues were identified in mac M1/M2 chip build:
- Issue with build version of protocArtifact and pluginArtifact properties.
- Java 1.8 incompatibility with M1 chip. Java 1.8 is not officially supported on the Apple M1 chip architecture. However, it is possible to install and use Java 1.8 on an M1-based Mac by using Rosetta 2, which is a built-in translation layer that allows apps designed for x86_64 architecture to run on Apple Silicon.

## Changes

There are two profiles defined: mac-os and other-os. The mac-os profile is activated when the operating system is Mac, and it sets the protocArtifact and pluginArtifact properties to constant values. The other-os profile is activated when the operating system is not Mac, and it uses the ${os.detected.classifier} variable in the protocArtifact and pluginArtifact properties.

## Issue Link

https://github.com/Concordium/concordium-java-sdk/issues/204

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- x] (If necessary) I have updated the CHANGELOG.

## Relevant Screenshots
<img width="2132" alt="Screenshot 2023-03-04 at 7 05 35 PM" src="https://user-images.githubusercontent.com/32020192/222905690-9d756c7b-846e-47b8-b1d2-d8c8d21ec898.png">
<img width="1094" alt="Screenshot 2023-03-05 at 7 27 06 PM" src="https://user-images.githubusercontent.com/32020192/222964851-e9617f7e-97b5-4222-bee4-68a8bd412f1a.png">


