### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
 ## Unreleased changes
+
+## 4.2.0
 - Added initial support for GRPC V2
 - Added initial support for GRPC V2 query GetAnonymityRevokers
 - Added CLI example for GRPC V2 query GetAnonymityRevokers
 - Added support for GRPC V2 GetBlocks
 - Added support for GRPC V2 GetFinalizedBlocks
+- Added support for M1/M2 Mac.
 
 ## 4.1.0
 - Added support for Transfer With Schedule.

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.concordium.sdk</groupId>
     <artifactId>concordium-sdk</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0</version>
 
     <name>concordium-sdk</name>
     <!-- FIXME change it to the project's website -->


### PR DESCRIPTION
## Purpose

Release 4.2.0 

- Added initial support for GRPC V2
- Added initial support for GRPC V2 query GetAnonymityRevokers
- Added CLI example for GRPC V2 query GetAnonymityRevokers
- Added support for GRPC V2 GetBlocks
- Added support for GRPC V2 GetFinalizedBlocks
- Added support for M1/M2 Mac.

## Changes

Updated the  CHANGELOG.md and version to 4.2.0.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.


