### PR TITLE
P6 variant in the ProtocolVersion

### DIFF
--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/ProtocolVersion.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/ProtocolVersion.java
@@ -26,7 +26,11 @@ public enum ProtocolVersion {
     /**
      * https://github.com/Concordium/concordium-update-proposals/blob/main/updates/P5.txt
      */
-    V5;
+    V5,
+    /**
+     * https://github.com/Concordium/concordium-update-proposals/blob/main/updates/P6.txt
+     */
+    V6;
 
     @JsonCreator
     public static ProtocolVersion forValue(int protocolVersion) {
@@ -36,6 +40,7 @@ public enum ProtocolVersion {
             case 3: return ProtocolVersion.V3;
             case 4: return ProtocolVersion.V4;
             case 5: return ProtocolVersion.V5;
+            case 6: return ProtocolVersion.V6;
             default:
                 throw new IllegalArgumentException("Unrecognized protocol version " + protocolVersion);
         }


### PR DESCRIPTION
## Purpose

Add the v6 to the ProtocolVersion enum.

Note that this does not directly give support for P6 (this is done here https://github.com/Concordium/concordium-java-sdk/pull/250) - hence the changelog will be updated as part of the pr mentioned.

But this serves the purpose of preventing that the v1 client cannot parse existing endpoints on P6.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
