### PR TITLE
Fix a bug where providers headers was not correctly set for `ClientV2`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Fix a bug that caused custom http headers to be set for `ClientV2`.
 
 ## 5.0.0
 

--- a/concordium-sdk-examples/pom.xml
+++ b/concordium-sdk-examples/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.concordium.sdk</groupId>
             <artifactId>concordium-sdk</artifactId>
-            <version>4.2.1-SNAPSHOT</version>
+            <version>5.0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -39,6 +39,7 @@ import com.concordium.sdk.types.ContractAddress;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
+import jdk.nashorn.internal.runtime.options.Option;
 import lombok.val;
 
 import java.io.File;
@@ -76,16 +77,26 @@ public final class ClientV2 {
 
     public static ClientV2 from(final Connection connection) throws ClientInitializationException {
         try {
-            return new ClientV2(connection.getTimeout(), connection.newChannel());
+            return new ClientV2(connection.getTimeout(), connection.newChannel(), Optional.ofNullable(connection.getCredentials()));
         } catch (IOException e) {
             throw ClientInitializationException.from(e);
         }
     }
 
-    ClientV2(final int timeout, final ManagedChannel channel) {
+    /**
+     * Construct a new client
+     * @param timeout The timeout in milliseconds.
+     * @param channel the underlying grpc channel.
+     * @param credentials Optionally extra headers.
+     */
+    ClientV2(final int timeout, final ManagedChannel channel, final Optional<Credentials> credentials) {
         this.timeout = timeout;
         this.channel = channel;
-        this.blockingStub = QueriesGrpc.newBlockingStub(channel);
+        if (credentials.isPresent()) {
+            this.blockingStub = QueriesGrpc.newBlockingStub(channel).withCallCredentials(credentials.get().getCallCredentials());
+        } else {
+            this.blockingStub = QueriesGrpc.newBlockingStub(channel);
+        }
     }
 
     /**

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2CryptographicParametersTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2CryptographicParametersTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -78,7 +80,7 @@ public class ClientV2CryptographicParametersTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
@@ -319,7 +319,7 @@ public class ClientV2GetAccountInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountListTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountListTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -68,7 +70,7 @@ public class ClientV2GetAccountListTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountNonFinalizedTransactionsTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountNonFinalizedTransactionsTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -59,7 +61,7 @@ public class ClientV2GetAccountNonFinalizedTransactionsTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAncestorsTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAncestorsTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -68,7 +70,7 @@ public class ClientV2GetAncestorsTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
 

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAnonymityRevokersTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAnonymityRevokersTest.java
@@ -7,6 +7,7 @@ import com.concordium.sdk.responses.blocksummary.updates.queues.AnonymityRevoker
 import com.concordium.sdk.transactions.Hash;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
+import io.grpc.CallCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -18,6 +19,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -86,7 +89,7 @@ public class ClientV2GetAnonymityRevokersTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBakerListTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBakerListTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -58,7 +60,7 @@ public class ClientV2GetBakerListTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBannedPeersTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBannedPeersTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -97,7 +98,7 @@ public class ClientV2GetBannedPeersTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockFinalizationSummaryTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockFinalizationSummaryTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -126,7 +127,7 @@ public class ClientV2GetBlockFinalizationSummaryTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockInfoTest.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -160,7 +162,7 @@ public class ClientV2GetBlockInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockItemStatusTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockItemStatusTest.java
@@ -22,6 +22,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static com.concordium.sdk.ClientV2MapperExtensions.to;
 import static com.concordium.sdk.ClientV2MapperExtensions.toTransactionHash;
 import static org.junit.Assert.assertEquals;
@@ -134,7 +136,7 @@ public class ClientV2GetBlockItemStatusTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockPendingUpdatesTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockPendingUpdatesTest.java
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -635,7 +636,7 @@ public class ClientV2GetBlockPendingUpdatesTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockSpecialEventsTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockSpecialEventsTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -243,7 +244,7 @@ public class ClientV2GetBlockSpecialEventsTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlocksTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlocksTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -74,7 +76,7 @@ public class ClientV2GetBlocksTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBranchesTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBranchesTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -63,7 +65,7 @@ public class ClientV2GetBranchesTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetConsensusStatusTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetConsensusStatusTest.java
@@ -15,6 +15,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -188,7 +190,7 @@ public class ClientV2GetConsensusStatusTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
 

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetElectionInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetElectionInfoTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -92,7 +94,7 @@ public class ClientV2GetElectionInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetIdentityProvidersTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetIdentityProvidersTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -96,7 +98,7 @@ public class ClientV2GetIdentityProvidersTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetInstanceInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetInstanceInfoTest.java
@@ -19,6 +19,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -88,7 +90,7 @@ public class ClientV2GetInstanceInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetInstanceListTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetInstanceListTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -56,7 +58,7 @@ public class ClientV2GetInstanceListTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetInstanceStateTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetInstanceStateTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -68,7 +70,7 @@ public class ClientV2GetInstanceStateTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetItemsTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetItemsTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static com.concordium.sdk.ClientV2MapperExtensions.to;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -169,7 +171,7 @@ public class ClientV2GetItemsTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetModuleListTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetModuleListTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -61,7 +63,7 @@ public class ClientV2GetModuleListTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetModuleSourceTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetModuleSourceTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -61,7 +63,7 @@ public class ClientV2GetModuleSourceTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetNextAccountSequenceNumberTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetNextAccountSequenceNumberTest.java
@@ -15,6 +15,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -61,7 +63,7 @@ public class ClientV2GetNextAccountSequenceNumberTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
 

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetNextUpdateSequenceNumbersTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetNextUpdateSequenceNumbersTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -103,7 +105,7 @@ public class ClientV2GetNextUpdateSequenceNumbersTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetNodeInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetNodeInfoTest.java
@@ -17,6 +17,8 @@ import lombok.val;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -217,7 +219,7 @@ public class ClientV2GetNodeInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
         return serviceImpl;
     }
 

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPassiveDelegatorsRewardPeriodTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPassiveDelegatorsRewardPeriodTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -83,7 +85,7 @@ public class ClientV2GetPassiveDelegatorsRewardPeriodTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPassiveDelegatorsTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPassiveDelegatorsTest.java
@@ -133,7 +133,7 @@ public class ClientV2GetPassiveDelegatorsTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     /**

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPeersInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPeersInfoTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
@@ -175,7 +176,7 @@ public class ClientV2GetPeersInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPoolDelegatorsRewardPeriodTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPoolDelegatorsRewardPeriodTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -86,7 +88,7 @@ public class ClientV2GetPoolDelegatorsRewardPeriodTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPoolDelegatorsTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPoolDelegatorsTest.java
@@ -134,7 +134,7 @@ public class ClientV2GetPoolDelegatorsTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel,Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPoolInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetPoolInfoTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
@@ -153,7 +155,7 @@ public class ClientV2GetPoolInfoTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetRewardsOverviewTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetRewardsOverviewTest.java
@@ -15,6 +15,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,7 +89,7 @@ public class ClientV2GetRewardsOverviewTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
 

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2SendAccountTransactionTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2SendAccountTransactionTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,7 +84,7 @@ public class ClientV2SendAccountTransactionTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2ShutdownTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2ShutdownTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.*;
 
@@ -43,7 +45,7 @@ public class ClientV2ShutdownTest {
                 .forName(serverName).directExecutor().addService(serviceImpl).build().start());
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
-        client = new ClientV2(10000, channel);
+        client = new ClientV2(10000, channel, Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Fix a bug that caused extra set http headers not to be included in requests for `ClientV2`.

## Changes

Add the `CallCredentials` to the underlying grpc stub if a connection has extra headers set.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

