### PR TITLE
Get block certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased changes
-- Added support for GRPC V2 `GetBlockCertificates` for retrieving certificates for a block supporting ConcordiumBFT
+- Added support for GRPC V2 `GetBlockCertificates` for retrieving certificates for a block supporting ConcordiumBF, i.e. a node with at least version 6.1.
 
 ## 5.1.0
 - Fixed a regression that made it harder to deserialize transactions from bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Added support for GRPC V2 `GetBlockCertificates` for retrieving certificates for a block supporting ConcordiumBFT
 
 ## 5.1.0
 - Fixed a regression that made it harder to deserialize transactions from bytes.

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetBlockCertificates.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetBlockCertificates.java
@@ -1,0 +1,44 @@
+package com.concordium.sdk.examples;
+
+import com.concordium.sdk.ClientV2;
+import com.concordium.sdk.Connection;
+import com.concordium.sdk.requests.BlockQuery;
+import lombok.val;
+import picocli.CommandLine;
+
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+/**
+ * Retrieves the BlockCertificates of the best block and prints it.
+ */
+@CommandLine.Command(name = "GetBlockCertificates", mixinStandardHelpOptions = true)
+public class GetBlockCertificates implements Callable<Integer> {
+
+    @CommandLine.Option(
+            names = {"--endpoint"},
+            description = "GRPC interface of the node.",
+            defaultValue = "http://localhost:20002")
+    private String endpoint;
+
+    @Override
+    public Integer call() throws Exception {
+        URL endpointUrl = new URL(this.endpoint);
+        Connection connection = Connection.newBuilder()
+                .host(endpointUrl.getHost())
+                .port(endpointUrl.getPort())
+                .build();
+
+        ClientV2 client = ClientV2.from(connection);
+
+
+        val blockCertificates = client.getBlockCertificates(BlockQuery.BEST);
+        System.out.println(blockCertificates);
+        return 0;
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new GetBlockCertificates()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -12,6 +12,7 @@ import com.concordium.sdk.responses.DelegatorInfo;
 import com.concordium.sdk.responses.DelegatorRewardPeriodInfo;
 import com.concordium.sdk.responses.*;
 import com.concordium.sdk.responses.accountinfo.AccountInfo;
+import com.concordium.sdk.responses.blockcertificates.BlockCertificates;
 import com.concordium.sdk.responses.blockinfo.BlockInfo;
 import com.concordium.sdk.responses.blockitemstatus.BlockItemStatus;
 import com.concordium.sdk.responses.blockitemsummary.Summary;
@@ -773,6 +774,18 @@ public final class ClientV2 {
 
         val grpcResponse = this.server().invokeInstance(grpcRequest.build());
         return InvokeInstanceResult.parse(grpcResponse);
+    }
+
+    /**
+     * Retrieves the {@link BlockCertificates} for a given block.
+     * Note that, if the block being pointed to is not a product of ConcordiumBFT, then a INVALID_ARGUMENT exception will be thrown.
+     * If the endpoint is not enabled by the node, then an 'UNIMPLEMENTED' exception will be thrown.
+     * @param block The block to query
+     * @return {@link BlockCertificates} of the block.
+     */
+    public BlockCertificates getBlockCertificates(BlockQuery block) {
+        val res = this.server().getBlockCertificates(to(block));
+        return BlockCertificates.from(res);
     }
 
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -778,7 +778,7 @@ public final class ClientV2 {
 
     /**
      * Retrieves the {@link BlockCertificates} for a given block.
-     * Note that, if the block being pointed to is not a product of ConcordiumBFT, then a INVALID_ARGUMENT exception will be thrown.
+     * Note that, if the block being pointed to is not a product of ConcordiumBFT, i.e. created before protocol version 6, then a INVALID_ARGUMENT exception will be thrown.
      * If the endpoint is not enabled by the node, then an 'UNIMPLEMENTED' exception will be thrown.
      * @param block The block to query
      * @return {@link BlockCertificates} of the block.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/crypto/BLSSignature.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/crypto/BLSSignature.java
@@ -1,0 +1,33 @@
+package com.concordium.sdk.crypto;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Arrays;
+
+@EqualsAndHashCode
+@ToString(includeFieldNames = false)
+public class BLSSignature {
+
+    private static final int FIXED_LENGTH = 48;
+
+    /**
+     * The bytes representing the raw aggregate signature. The bytes have a fixed length of {@value BLSSignature#FIXED_LENGTH} bytes.
+     */
+    private final byte[] bytes;
+
+    private BLSSignature(final byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Builder
+    public static BLSSignature from(final byte[] sig) {
+        if (! (sig.length == 48)) {throw new IllegalArgumentException("BLSSignature must have fixed length of " + FIXED_LENGTH + " bytes"); }
+        return new BLSSignature(sig);
+    }
+
+    public byte[] getBytes() {
+        return Arrays.copyOf(bytes, bytes.length);
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/Epoch.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/Epoch.java
@@ -25,4 +25,8 @@ public class Epoch {
     public static Epoch from(long x) {
         return new Epoch(UInt64.from(x));
     }
+
+    public static Epoch from(com.concordium.grpc.v2.Epoch epoch) {
+        return from(epoch.getValue());
+    }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/Round.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/Round.java
@@ -29,4 +29,8 @@ public class Round {
     public static Round from(long round) {
         return new Round(UInt64.from(round));
     }
+
+    public static Round from(com.concordium.grpc.v2.Round round) {
+        return from(round.getValue());
+    }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/BlockCertificates.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/BlockCertificates.java
@@ -1,11 +1,13 @@
 package com.concordium.sdk.responses.blockcertificates;
 
+import com.concordium.sdk.responses.Round;
 import lombok.*;
 
 import java.util.Optional;
 
 /**
  * Certificates for a block for protocols supporting ConcordiumBFT.
+ * ConcordiumBFT progresses to a new {@link Round} either via a {@link QuorumCertificate} or a {@link TimeoutCertificate} for a particular round.
  */
 @EqualsAndHashCode
 @Builder

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/BlockCertificates.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/BlockCertificates.java
@@ -1,0 +1,59 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import lombok.*;
+
+import java.util.Optional;
+
+/**
+ * Certificates for a block for protocols supporting ConcordiumBFT.
+ */
+@EqualsAndHashCode
+@Builder
+@ToString(doNotUseGetters = true)
+public class BlockCertificates {
+
+    /**
+     * The quorum certificate. Is present if and only if the block is not a genesis block.
+     */
+    private final QuorumCertificate quorumCertificate;
+    /**
+     * The timeout certificate. Is present only if the round prior to the round of the block timed out.
+     */
+    private final TimeoutCertificate timeoutCertificate;
+    /**
+     * The epoch finalization entry. Is present only if the block initiates a new epoch.
+     */
+    private final EpochFinalizationEntry epochFinalizationEntry;
+
+    public Optional<QuorumCertificate> getQuorumCertificate() {
+        return Optional.ofNullable(quorumCertificate);
+    }
+
+    public Optional<TimeoutCertificate> getTimeoutCertificate() {
+        return Optional.ofNullable(timeoutCertificate);
+    }
+
+    public Optional<EpochFinalizationEntry> getEpochFinalizationEntry() {
+        return Optional.ofNullable(epochFinalizationEntry);
+    }
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.BlockCertificates} to {@link BlockCertificates}.
+     *
+     * @param certificates {@link com.concordium.grpc.v2.BlockCertificates} returned by the GRPC v2 API.
+     * @return parsed {@link BlockCertificates}.
+     */
+    public static BlockCertificates from(com.concordium.grpc.v2.BlockCertificates certificates) {
+        val b = BlockCertificates.builder();
+        if (certificates.hasQuorumCertificate()) {
+            b.quorumCertificate(QuorumCertificate.from(certificates.getQuorumCertificate()));
+        }
+        if (certificates.hasTimeoutCertificate()) {
+            b.timeoutCertificate(TimeoutCertificate.from(certificates.getTimeoutCertificate()));
+        }
+        if (certificates.hasEpochFinalizationEntry()) {
+            b.epochFinalizationEntry(EpochFinalizationEntry.from(certificates.getEpochFinalizationEntry()));
+        }
+        return b.build();
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/EpochFinalizationEntry.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/EpochFinalizationEntry.java
@@ -1,0 +1,44 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import com.concordium.sdk.responses.Epoch;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * The epoch finalization entry is the proof that makes the protocol able to advance to a new epoch.
+ * I.e. the {@link EpochFinalizationEntry} is present if and only if the block is the first block of a new {@link Epoch}.
+ */
+@Builder
+@Getter
+@ToString
+@EqualsAndHashCode
+
+public class EpochFinalizationEntry {
+    /**
+     * The quorum certificate for the finalized block.
+     */
+    private final QuorumCertificate finalizedQc;
+    /**
+     * The quorum certificate for the block that finalizes the block that {@link EpochFinalizationEntry#finalizedQc} points to.
+     */
+    private final QuorumCertificate successorQc;
+    /**
+     * A proof that the successor block is an immediate successor of the finalized block.
+     */
+    private final SuccessorProof successorProof;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.EpochFinalizationEntry} to {@link EpochFinalizationEntry}.
+      * @param entry {@link com.concordium.grpc.v2.EpochFinalizationEntry} returned by the GRPC v2 API.
+     * @return parsed {@link EpochFinalizationEntry}.
+     */
+    public static EpochFinalizationEntry from(com.concordium.grpc.v2.EpochFinalizationEntry entry) {
+        return EpochFinalizationEntry.builder()
+                .finalizedQc(QuorumCertificate.from(entry.getFinalizedQc()))
+                .successorQc(QuorumCertificate.from(entry.getSuccessorQc()))
+                .successorProof(SuccessorProof.from(entry.getSuccessorProof()))
+                .build();
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/EpochFinalizationEntry.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/EpochFinalizationEntry.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 @Getter
 @ToString
 @EqualsAndHashCode
-
 public class EpochFinalizationEntry {
     /**
      * The quorum certificate for the finalized block.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/FinalizerRound.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/FinalizerRound.java
@@ -1,0 +1,43 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import com.concordium.sdk.responses.BakerId;
+import com.concordium.sdk.responses.Round;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The finalizer round is a map from a {@link Round} to the list of finalizers (identified by their {@link BakerId})
+ * that signed off the round.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class FinalizerRound {
+    /**
+     * The round that was signed off.
+     */
+    private final Round round;
+    /**
+     * The finalizers (identified by their {@link BakerId}) that signed off the in {@link FinalizerRound#round}.
+     */
+    private final List<BakerId> finalizers;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.FinalizerRound} to {@link FinalizerRound}.
+     * @param finalizerRound {@link com.concordium.grpc.v2.FinalizerRound} returned by the GRPC v2 API.
+     * @return parsed {@link FinalizerRound}.
+     */
+    public static FinalizerRound from(com.concordium.grpc.v2.FinalizerRound finalizerRound) {
+        val finalizers = new ArrayList<BakerId>();
+        finalizerRound.getFinalizersList().forEach(
+                f -> finalizers.add(BakerId.from(f))
+        );
+        return FinalizerRound.builder()
+                .round(Round.from(finalizerRound.getRound()))
+                .finalizers(finalizers).build();
+
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/QuorumCertificate.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/QuorumCertificate.java
@@ -1,0 +1,62 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import com.concordium.sdk.responses.BakerId;
+import com.concordium.sdk.responses.Epoch;
+import com.concordium.sdk.responses.Round;
+import com.concordium.sdk.transactions.Hash;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A quorum certificate is the certificate that the finalization committee issues in order to certify a block.
+ * A block must be certified before it will be part of the authoritative part of the chain.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class QuorumCertificate {
+
+    /**
+     * The hash of the block that the quorum certificate refers to.
+     */
+    private final Hash blockHash;
+    /**
+     * The round of the block.
+     */
+    private final Round round;
+    /**
+     * The epoch of the block.
+     */
+    private final Epoch epoch;
+    /**
+     * The aggregated signature by the finalization committee on the block.
+     */
+    private final QuorumSignature aggregateSignature;
+    /**
+     * A list of the finalizers that formed the quorum certificate i.e., the ones who have contributed to the {@link QuorumCertificate#aggregateSignature}.
+     * The finalizers are identified by their {@link BakerId} as this is stable across protocols and epochs.
+     */
+    private final List<BakerId> signatories;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.QuorumCertificate} to {@link QuorumCertificate}.
+     * @param certificate {@link com.concordium.grpc.v2.QuorumCertificate} returned by the GRPC v2 API.
+     * @return parsed {@link QuorumCertificate}.
+     */
+    public static QuorumCertificate from(com.concordium.grpc.v2.QuorumCertificate certificate) {
+        val signatories = new ArrayList<BakerId>();
+        certificate.getSignatoriesList().forEach(
+                s -> signatories.add(BakerId.from(s))
+        );
+        return QuorumCertificate.builder()
+                .blockHash(Hash.from(certificate.getBlockHash()))
+                .round(Round.from(certificate.getRound()))
+                .epoch(Epoch.from(certificate.getEpoch()))
+                .aggregateSignature(QuorumSignature.from(certificate.getAggregateSignature()))
+                .signatories(signatories)
+                .build();
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/QuorumSignature.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/QuorumSignature.java
@@ -1,5 +1,6 @@
 package com.concordium.sdk.responses.blockcertificates;
 
+import com.concordium.sdk.crypto.BLSSignature;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -15,9 +16,9 @@ import lombok.ToString;
 public class QuorumSignature {
 
     /**
-     * The bytes representing the raw aggregate signature. The bytes have a fixed length of 48 bytes.
+     * The aggregate {@link BLSSignature}.
      */
-    private final byte[] value;
+    private final BLSSignature value;
 
     /**
      * Parses {@link com.concordium.grpc.v2.QuorumSignature} to {@link QuorumSignature}.
@@ -25,6 +26,8 @@ public class QuorumSignature {
      * @return parsed {@link QuorumSignature}.
      */
     public static QuorumSignature from(com.concordium.grpc.v2.QuorumSignature sig) {
-        return QuorumSignature.builder().value(sig.getValue().toByteArray()).build();
+        return QuorumSignature.builder()
+                .value(BLSSignature.from(sig.getValue().toByteArray()))
+                .build();
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/QuorumSignature.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/QuorumSignature.java
@@ -1,0 +1,30 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * The signature of a {@link QuorumCertificate}.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class QuorumSignature {
+
+    /**
+     * The bytes representing the raw aggregate signature. The bytes have a fixed length of 48 bytes.
+     */
+    private final byte[] value;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.QuorumSignature} to {@link QuorumSignature}.
+     * @param sig {@link com.concordium.grpc.v2.QuorumSignature} returned by the GRPC v2 API.
+     * @return parsed {@link QuorumSignature}.
+     */
+    public static QuorumSignature from(com.concordium.grpc.v2.QuorumSignature sig) {
+        return QuorumSignature.builder().value(sig.getValue().toByteArray()).build();
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/SuccessorProof.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/SuccessorProof.java
@@ -1,0 +1,31 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * A proof that establishes that the successor block of
+ * a {@link EpochFinalizationEntry} is the immediate successor of
+ * the finalized block.
+ */
+@Getter
+@Builder
+@EqualsAndHashCode
+@ToString
+public class SuccessorProof {
+    /**
+     * The proof represented as raw bytes. The bytes have a fixed length of 32 bytes.
+     */
+    private final byte[] value;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.SuccessorProof} to {@link SuccessorProof}.
+     * @param proof {@link com.concordium.grpc.v2.SuccessorProof} returned by the GRCP v2 API.
+     * @return parsed {@link SuccessorProof}.
+     */
+    public static SuccessorProof from(com.concordium.grpc.v2.SuccessorProof proof) {
+        return SuccessorProof.builder().value(proof.getValue().toByteArray()).build();
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/SuccessorProof.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/SuccessorProof.java
@@ -1,5 +1,6 @@
 package com.concordium.sdk.responses.blockcertificates;
 
+import com.concordium.sdk.transactions.Hash;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -16,9 +17,9 @@ import lombok.ToString;
 @ToString
 public class SuccessorProof {
     /**
-     * The proof represented as raw bytes. The bytes have a fixed length of 32 bytes.
+     * The proof.
      */
-    private final byte[] value;
+    private final Hash value;
 
     /**
      * Parses {@link com.concordium.grpc.v2.SuccessorProof} to {@link SuccessorProof}.
@@ -26,6 +27,6 @@ public class SuccessorProof {
      * @return parsed {@link SuccessorProof}.
      */
     public static SuccessorProof from(com.concordium.grpc.v2.SuccessorProof proof) {
-        return SuccessorProof.builder().value(proof.getValue().toByteArray()).build();
+        return SuccessorProof.builder().value(Hash.from(proof.getValue().toByteArray())).build();
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/TimeoutCertificate.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/TimeoutCertificate.java
@@ -1,0 +1,62 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import com.concordium.sdk.responses.Epoch;
+import com.concordium.sdk.responses.Round;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A timeout certificate is the certificate that the finalization committee issues when a round times out,
+ * thus making it possible for the protocol to proceed to the next round.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class TimeoutCertificate {
+    /**
+     * The round that timed out.
+     */
+    private final Round round;
+    /**
+     * The minimum epoch of which signatures are included in the {@link TimeoutCertificate#aggregateSignature}.
+     */
+    private final Epoch minEpoch;
+    /**
+     * The rounds of which finalizers have their best QCs in the {@link TimeoutCertificate#minEpoch}.
+     */
+    private final List<FinalizerRound> qcRoundsFirstEpoch;
+    /**
+     * The rounds of which finalizers have their best QCs in the epoch {@link TimeoutCertificate#minEpoch} + 1.
+     */
+    private final List<FinalizerRound> qcRoundsSecondEpoch;
+    /**
+     * The aggregated signature by the finalization committee that witnessed the {@link TimeoutCertificate#round} timed out.
+     */
+    private final TimeoutSignature aggregateSignature;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.TimeoutCertificate} to {@link TimeoutCertificate}.
+     * @param certificate {@link com.concordium.grpc.v2.TimeoutCertificate} returned by the GRPC v2 API.
+     * @return parsed {@link TimeoutCertificate}.
+     */
+    public static TimeoutCertificate from(com.concordium.grpc.v2.TimeoutCertificate certificate) {
+        val firstEpochList = new ArrayList<FinalizerRound>();
+        val secondEpochList = new ArrayList<FinalizerRound>();
+        certificate.getQcRoundsFirstEpochList().forEach(
+                f -> firstEpochList.add(FinalizerRound.from(f))
+        );
+        certificate.getQcRoundsSecondEpochList().forEach(
+                f -> secondEpochList.add(FinalizerRound.from(f))
+        );
+        return TimeoutCertificate.builder()
+                .round(Round.from(certificate.getRound()))
+                .minEpoch(Epoch.from(certificate.getMinEpoch()))
+                .qcRoundsFirstEpoch(firstEpochList)
+                .qcRoundsSecondEpoch(secondEpochList)
+                .aggregateSignature(TimeoutSignature.from(certificate.getAggregateSignature()))
+                .build();
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/TimeoutSignature.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/TimeoutSignature.java
@@ -1,5 +1,6 @@
 package com.concordium.sdk.responses.blockcertificates;
 
+import com.concordium.sdk.crypto.BLSSignature;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,9 +15,9 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class TimeoutSignature {
     /**
-     * The bytes representing the raw aggregate signature. The bytes have a fixed length of 48 bytes.
+     * The aggregate {@link BLSSignature}.
      */
-    private final byte[] value;
+    private final BLSSignature value;
 
     /**
      * Parses {@link com.concordium.grpc.v2.TimeoutSignature} to {@link TimeoutSignature}.
@@ -24,6 +25,8 @@ public class TimeoutSignature {
      * @return parsed {@link TimeoutSignature}.
      */
     public static TimeoutSignature from(com.concordium.grpc.v2.TimeoutSignature sig) {
-        return TimeoutSignature.builder().value(sig.getValue().toByteArray()).build();
+        return TimeoutSignature.builder()
+                .value(BLSSignature.from(sig.getValue().toByteArray()))
+                .build();
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/TimeoutSignature.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/blockcertificates/TimeoutSignature.java
@@ -1,0 +1,29 @@
+package com.concordium.sdk.responses.blockcertificates;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * The signature of a {@link TimeoutCertificate}.
+ */
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+public class TimeoutSignature {
+    /**
+     * The bytes representing the raw aggregate signature. The bytes have a fixed length of 48 bytes.
+     */
+    private final byte[] value;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.TimeoutSignature} to {@link TimeoutSignature}.
+     * @param sig {@link com.concordium.grpc.v2.TimeoutSignature} returned by the GRCP v2 API.
+     * @return parsed {@link TimeoutSignature}.
+     */
+    public static TimeoutSignature from(com.concordium.grpc.v2.TimeoutSignature sig) {
+        return TimeoutSignature.builder().value(sig.getValue().toByteArray()).build();
+    }
+}

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockCertificatesTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockCertificatesTest.java
@@ -1,6 +1,7 @@
 package com.concordium.sdk;
 
 import com.concordium.grpc.v2.*;
+import com.concordium.sdk.crypto.BLSSignature;
 import com.concordium.sdk.requests.BlockQuery;
 import com.concordium.sdk.responses.BakerId;
 import com.concordium.sdk.responses.Epoch;
@@ -100,7 +101,7 @@ public class ClientV2GetBlockCertificatesTest {
                     .round(Round.from(ROUND_1))
                     .epoch(Epoch.from(EPOCH_1))
                     .aggregateSignature(com.concordium.sdk.responses.blockcertificates.QuorumSignature
-                            .builder().value(QUORUM_SIG_1)
+                            .builder().value(BLSSignature.from(QUORUM_SIG_1))
                             .build())
                     .signatories(CLIENT_BAKER_ID_LIST_1)
                     .build();
@@ -110,7 +111,7 @@ public class ClientV2GetBlockCertificatesTest {
                     .round(Round.from(ROUND_2))
                     .epoch(Epoch.from(EPOCH_2))
                     .aggregateSignature(com.concordium.sdk.responses.blockcertificates.QuorumSignature
-                            .builder().value(QUORUM_SIG_2)
+                            .builder().value(BLSSignature.from(QUORUM_SIG_2))
                             .build())
                     .signatories(CLIENT_BAKER_ID_LIST_2)
                     .build();
@@ -122,7 +123,7 @@ public class ClientV2GetBlockCertificatesTest {
                     .qcRoundsFirstEpoch(CLIENT_FINALIZER_ROUND_LIST_1)
                     .qcRoundsSecondEpoch(CLIENT_FINALIZER_ROUND_LIST_2)
                     .aggregateSignature(com.concordium.sdk.responses.blockcertificates.TimeoutSignature
-                            .builder().value(TIMEOUT_SIG_1)
+                            .builder().value(BLSSignature.from(TIMEOUT_SIG_1))
                             .build())
                     .build();
 
@@ -131,7 +132,7 @@ public class ClientV2GetBlockCertificatesTest {
                     .finalizedQc(CLIENT_QUORUM_CERTIFICATE_1)
                     .successorQc(CLIENT_QUORUM_CERTIFICATE_2)
                     .successorProof(com.concordium.sdk.responses.blockcertificates.SuccessorProof
-                            .builder().value(SUCCESSOR_PROOF_1).build())
+                            .builder().value(Hash.from(SUCCESSOR_PROOF_1)).build())
                     .build();
     // Client Block Certificates
     private static final com.concordium.sdk.responses.blockcertificates.BlockCertificates CLIENT_BLOCK_CERT_WITH_QUORUM =

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockCertificatesTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetBlockCertificatesTest.java
@@ -1,0 +1,321 @@
+package com.concordium.sdk;
+
+import com.concordium.grpc.v2.*;
+import com.concordium.sdk.requests.BlockQuery;
+import com.concordium.sdk.responses.BakerId;
+import com.concordium.sdk.responses.Epoch;
+import com.concordium.sdk.responses.Round;
+import com.concordium.sdk.responses.blockcertificates.QuorumCertificate;
+import com.concordium.sdk.transactions.Hash;
+import com.google.protobuf.ByteString;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ClientV2GetBlockCertificatesTest {
+
+    // ---- Test Values ----
+    private static final byte[] HASH_1 = new byte[]{1, 2, 3};
+    private static final byte[] HASH_2 = new byte[]{4, 5, 6};
+    private static final long ROUND_1 = 1;
+    private static final long ROUND_2 = 2;
+    private static final long ROUND_3 = 2;
+    private static final long ROUND_4 = 2;
+    private static final long EPOCH_1 = 1;
+    private static final long EPOCH_2 = 2;
+    private static final byte[] QUORUM_SIG_1 = bytesOfLength(48, 1);
+    private static final byte[] QUORUM_SIG_2 = bytesOfLength(48, 2);
+    private static final byte[] TIMEOUT_SIG_1 = bytesOfLength(48, 3);
+    private static final byte[] SUCCESSOR_PROOF_1 = bytesOfLength(32, 4);
+    private static final long BAKER_ID_1 = 1;
+    private static final long BAKER_ID_2 = 2;
+    private static final long BAKER_ID_3 = 3;
+    private static final long BAKER_ID_4 = 4;
+    private static final long BAKER_ID_5 = 5;
+    private static final long BAKER_ID_6 = 6;
+    private static final long BAKER_ID_7 = 7;
+    private static final long BAKER_ID_8 = 8;
+
+
+    // ---- Client values ----
+
+    private static final List<BakerId> CLIENT_BAKER_ID_LIST_1 = new ArrayList<>(Arrays.asList(
+            BakerId.from(BAKER_ID_1), BakerId.from(BAKER_ID_2)
+    ));
+    private static final List<BakerId> CLIENT_BAKER_ID_LIST_2 = new ArrayList<>(Arrays.asList(
+            BakerId.from(BAKER_ID_3), BakerId.from(BAKER_ID_4)
+    ));
+    private static final List<BakerId> CLIENT_BAKER_ID_LIST_3 = new ArrayList<>(Arrays.asList(
+            BakerId.from(BAKER_ID_5), BakerId.from(BAKER_ID_6)
+    ));
+    private static final List<BakerId> CLIENT_BAKER_ID_LIST_4 = new ArrayList<>(Arrays.asList(
+            BakerId.from(BAKER_ID_7), BakerId.from(BAKER_ID_8)
+    ));
+
+    private static final com.concordium.sdk.responses.blockcertificates.FinalizerRound CLIENT_FINALIZER_ROUND_1 =
+            com.concordium.sdk.responses.blockcertificates.FinalizerRound.builder()
+                    .round(Round.from(ROUND_1))
+                    .finalizers(CLIENT_BAKER_ID_LIST_1)
+                    .build();
+    private static final com.concordium.sdk.responses.blockcertificates.FinalizerRound CLIENT_FINALIZER_ROUND_2 =
+            com.concordium.sdk.responses.blockcertificates.FinalizerRound.builder()
+                    .round(Round.from(ROUND_2))
+                    .finalizers(CLIENT_BAKER_ID_LIST_2)
+                    .build();
+    private static final com.concordium.sdk.responses.blockcertificates.FinalizerRound CLIENT_FINALIZER_ROUND_3 =
+            com.concordium.sdk.responses.blockcertificates.FinalizerRound.builder()
+                    .round(Round.from(ROUND_3))
+                    .finalizers(CLIENT_BAKER_ID_LIST_3)
+                    .build();
+    private static final com.concordium.sdk.responses.blockcertificates.FinalizerRound CLIENT_FINALIZER_ROUND_4 =
+            com.concordium.sdk.responses.blockcertificates.FinalizerRound.builder()
+                    .round(Round.from(ROUND_4))
+                    .finalizers(CLIENT_BAKER_ID_LIST_4)
+                    .build();
+    private static final List<com.concordium.sdk.responses.blockcertificates.FinalizerRound> CLIENT_FINALIZER_ROUND_LIST_1 =
+            new ArrayList<>(Arrays.asList(CLIENT_FINALIZER_ROUND_1, CLIENT_FINALIZER_ROUND_2));
+    private static final List<com.concordium.sdk.responses.blockcertificates.FinalizerRound> CLIENT_FINALIZER_ROUND_LIST_2 =
+            new ArrayList<>(Arrays.asList(CLIENT_FINALIZER_ROUND_3, CLIENT_FINALIZER_ROUND_4));
+    private static final QuorumCertificate CLIENT_QUORUM_CERTIFICATE_1 =
+            QuorumCertificate.builder()
+                    .blockHash(Hash.from(HASH_1))
+                    .round(Round.from(ROUND_1))
+                    .epoch(Epoch.from(EPOCH_1))
+                    .aggregateSignature(com.concordium.sdk.responses.blockcertificates.QuorumSignature
+                            .builder().value(QUORUM_SIG_1)
+                            .build())
+                    .signatories(CLIENT_BAKER_ID_LIST_1)
+                    .build();
+    private static final QuorumCertificate CLIENT_QUORUM_CERTIFICATE_2 =
+            QuorumCertificate.builder()
+                    .blockHash(Hash.from(HASH_2))
+                    .round(Round.from(ROUND_2))
+                    .epoch(Epoch.from(EPOCH_2))
+                    .aggregateSignature(com.concordium.sdk.responses.blockcertificates.QuorumSignature
+                            .builder().value(QUORUM_SIG_2)
+                            .build())
+                    .signatories(CLIENT_BAKER_ID_LIST_2)
+                    .build();
+
+    private static final com.concordium.sdk.responses.blockcertificates.TimeoutCertificate CLIENT_TIMEOUT_CERTIFICATE =
+            com.concordium.sdk.responses.blockcertificates.TimeoutCertificate.builder()
+                    .round(Round.from(ROUND_2))
+                    .minEpoch(Epoch.from(EPOCH_2))
+                    .qcRoundsFirstEpoch(CLIENT_FINALIZER_ROUND_LIST_1)
+                    .qcRoundsSecondEpoch(CLIENT_FINALIZER_ROUND_LIST_2)
+                    .aggregateSignature(com.concordium.sdk.responses.blockcertificates.TimeoutSignature
+                            .builder().value(TIMEOUT_SIG_1)
+                            .build())
+                    .build();
+
+    private static final com.concordium.sdk.responses.blockcertificates.EpochFinalizationEntry CLIENT_FINALIZATION_ENTRY =
+            com.concordium.sdk.responses.blockcertificates.EpochFinalizationEntry.builder()
+                    .finalizedQc(CLIENT_QUORUM_CERTIFICATE_1)
+                    .successorQc(CLIENT_QUORUM_CERTIFICATE_2)
+                    .successorProof(com.concordium.sdk.responses.blockcertificates.SuccessorProof
+                            .builder().value(SUCCESSOR_PROOF_1).build())
+                    .build();
+    // Client Block Certificates
+    private static final com.concordium.sdk.responses.blockcertificates.BlockCertificates CLIENT_BLOCK_CERT_WITH_QUORUM =
+            com.concordium.sdk.responses.blockcertificates.BlockCertificates.builder()
+                    .quorumCertificate(CLIENT_QUORUM_CERTIFICATE_1).build();
+    private static final com.concordium.sdk.responses.blockcertificates.BlockCertificates CLIENT_BLOCK_CERT_WITH_TIMEOUT =
+            com.concordium.sdk.responses.blockcertificates.BlockCertificates.builder()
+                    .timeoutCertificate(CLIENT_TIMEOUT_CERTIFICATE).build();
+    private static final com.concordium.sdk.responses.blockcertificates.BlockCertificates CLIENT_BLOCK_CERT_WITH_FINALIZATION =
+            com.concordium.sdk.responses.blockcertificates.BlockCertificates.builder()
+                    .epochFinalizationEntry(CLIENT_FINALIZATION_ENTRY).build();
+    private static final com.concordium.sdk.responses.blockcertificates.BlockCertificates CLIENT_BLOCK_CERT_WITH_ALL =
+            com.concordium.sdk.responses.blockcertificates.BlockCertificates.builder()
+                    .quorumCertificate(CLIENT_QUORUM_CERTIFICATE_1)
+                    .timeoutCertificate(CLIENT_TIMEOUT_CERTIFICATE)
+                    .epochFinalizationEntry(CLIENT_FINALIZATION_ENTRY)
+                    .build();
+
+
+    // ---- GRPC Values ----
+
+    private static final List<com.concordium.grpc.v2.BakerId> GRPC_BAKER_ID_LIST_1 = new ArrayList<>(Arrays.asList(
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_1).build(),
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_2).build()
+    ));
+    private static final List<com.concordium.grpc.v2.BakerId> GRPC_BAKER_ID_LIST_2 = new ArrayList<>(Arrays.asList(
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_3).build(),
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_4).build()
+    ));
+    private static final List<com.concordium.grpc.v2.BakerId> GRPC_BAKER_ID_LIST_3 = new ArrayList<>(Arrays.asList(
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_5).build(),
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_6).build()
+    ));
+    private static final List<com.concordium.grpc.v2.BakerId> GRPC_BAKER_ID_LIST_4 = new ArrayList<>(Arrays.asList(
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_7).build(),
+            com.concordium.grpc.v2.BakerId.newBuilder().setValue(BAKER_ID_8).build()
+    ));
+
+    private static final FinalizerRound GRPC_FINALIZER_ROUND_1 = FinalizerRound.newBuilder()
+            .setRound(com.concordium.grpc.v2.Round.newBuilder().setValue(ROUND_1).build())
+            .addAllFinalizers(GRPC_BAKER_ID_LIST_1)
+            .build();
+    private static final FinalizerRound GRPC_FINALIZER_ROUND_2 = FinalizerRound.newBuilder()
+            .setRound(com.concordium.grpc.v2.Round.newBuilder().setValue(ROUND_2).build())
+            .addAllFinalizers(GRPC_BAKER_ID_LIST_2)
+            .build();
+    private static final FinalizerRound GRPC_FINALIZER_ROUND_3 = FinalizerRound.newBuilder()
+            .setRound(com.concordium.grpc.v2.Round.newBuilder().setValue(ROUND_3).build())
+            .addAllFinalizers(GRPC_BAKER_ID_LIST_3)
+            .build();
+    private static final FinalizerRound GRPC_FINALIZER_ROUND_4 = FinalizerRound.newBuilder()
+            .setRound(com.concordium.grpc.v2.Round.newBuilder().setValue(ROUND_4).build())
+            .addAllFinalizers(GRPC_BAKER_ID_LIST_4)
+            .build();
+
+    private static final List<FinalizerRound> GRPC_FINALIZER_ROUND_LIST_1 = new ArrayList<>(Arrays.asList(
+            GRPC_FINALIZER_ROUND_1, GRPC_FINALIZER_ROUND_2
+    ));
+    private static final List<FinalizerRound> GRPC_FINALIZER_ROUND_LIST_2 = new ArrayList<>(Arrays.asList(
+            GRPC_FINALIZER_ROUND_3, GRPC_FINALIZER_ROUND_4
+    ));
+
+
+    private static final com.concordium.grpc.v2.QuorumCertificate GRPC_QUORUM_CERTIFICATE_1 =
+            com.concordium.grpc.v2.QuorumCertificate.newBuilder()
+                    .setBlockHash(
+                            BlockHash.newBuilder().setValue(ByteString.copyFrom(HASH_1))
+                                    .build())
+                    .setRound(com.concordium.grpc.v2.Round.newBuilder()
+                            .setValue(ROUND_1)
+                            .build())
+                    .setEpoch(com.concordium.grpc.v2.Epoch.newBuilder()
+                            .setValue(EPOCH_1)
+                            .build())
+                    .setAggregateSignature(QuorumSignature.newBuilder()
+                            .setValue(ByteString.copyFrom(QUORUM_SIG_1)).build())
+                    .addAllSignatories(GRPC_BAKER_ID_LIST_1)
+                    .build();
+    private static final com.concordium.grpc.v2.QuorumCertificate GRPC_QUORUM_CERTIFICATE_2 =
+            com.concordium.grpc.v2.QuorumCertificate.newBuilder()
+                    .setBlockHash(
+                            BlockHash.newBuilder().setValue(ByteString.copyFrom(HASH_2))
+                                    .build())
+                    .setRound(com.concordium.grpc.v2.Round.newBuilder()
+                            .setValue(ROUND_2)
+                            .build())
+                    .setEpoch(com.concordium.grpc.v2.Epoch.newBuilder()
+                            .setValue(EPOCH_2)
+                            .build())
+                    .setAggregateSignature(QuorumSignature.newBuilder()
+                            .setValue(ByteString.copyFrom(QUORUM_SIG_2)).build())
+                    .addAllSignatories(GRPC_BAKER_ID_LIST_2)
+                    .build();
+
+    private static final TimeoutCertificate GRPC_TIMEOUT_CERTIFICATE =
+            TimeoutCertificate.newBuilder()
+                    .setRound(com.concordium.grpc.v2.Round.newBuilder().setValue(ROUND_2).build())
+                    .setMinEpoch(com.concordium.grpc.v2.Epoch.newBuilder().setValue(EPOCH_2).build())
+                    .addAllQcRoundsFirstEpoch(GRPC_FINALIZER_ROUND_LIST_1)
+                    .addAllQcRoundsSecondEpoch(GRPC_FINALIZER_ROUND_LIST_2)
+                    .setAggregateSignature(TimeoutSignature.newBuilder().setValue(ByteString.copyFrom(TIMEOUT_SIG_1)).build())
+                    .build();
+
+    private static final EpochFinalizationEntry GRPC_FINALIZATION_ENTRY =
+            EpochFinalizationEntry.newBuilder()
+                    .setFinalizedQc(GRPC_QUORUM_CERTIFICATE_1)
+                    .setSuccessorQc(GRPC_QUORUM_CERTIFICATE_2)
+                    .setSuccessorProof(SuccessorProof.newBuilder()
+                            .setValue(ByteString.copyFrom(SUCCESSOR_PROOF_1)).build())
+                    .build();
+    // GRPC Block Certificates
+    private static final BlockCertificates GRPC_BLOCK_CERT_WITH_QUORUM = BlockCertificates.newBuilder()
+            .setQuorumCertificate(GRPC_QUORUM_CERTIFICATE_1).build();
+    private static final BlockCertificates GRPC_BLOCK_CERT_WITH_TIMEOUT = BlockCertificates.newBuilder()
+            .setTimeoutCertificate(GRPC_TIMEOUT_CERTIFICATE).build();
+    private static final BlockCertificates GRPC_BLOCK_CERT_WITH_FINALIZATION = BlockCertificates.newBuilder()
+            .setEpochFinalizationEntry(GRPC_FINALIZATION_ENTRY).build();
+    private static final BlockCertificates GRPC_BLOCK_CERT_WITH_ALL = BlockCertificates.newBuilder()
+            .setQuorumCertificate(GRPC_QUORUM_CERTIFICATE_1)
+            .setTimeoutCertificate(GRPC_TIMEOUT_CERTIFICATE)
+            .setEpochFinalizationEntry(GRPC_FINALIZATION_ENTRY)
+            .build();
+
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+    private ClientV2 client;
+
+    // Must be first line of every test as it acts as a setup method as well
+    private QueriesGrpc.QueriesImplBase configureResponseAndSetup(BlockCertificates response) throws Exception {
+        QueriesGrpc.QueriesImplBase serviceImpl = mock(QueriesGrpc.QueriesImplBase.class, delegatesTo(
+                new QueriesGrpc.QueriesImplBase() {
+                    @Override
+                    public void getBlockCertificates(BlockHashInput request, StreamObserver<BlockCertificates> responseObserver) {
+                        responseObserver.onNext(response);
+                        responseObserver.onCompleted();
+                    }
+                }));
+        String serverName = InProcessServerBuilder.generateName();
+        grpcCleanup.register(InProcessServerBuilder
+                .forName(serverName).directExecutor().addService(serviceImpl).build().start());
+        ManagedChannel channel = grpcCleanup.register(
+                InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        client = new ClientV2(10000, channel, Optional.empty());
+        return serviceImpl;
+    }
+
+    @SneakyThrows
+    @Test
+    public void getQuorumBlockCert() {
+        test(GRPC_BLOCK_CERT_WITH_QUORUM, CLIENT_BLOCK_CERT_WITH_QUORUM);
+    }
+
+    @SneakyThrows
+    @Test
+    public void getTimeoutBlockCert() {
+        test(GRPC_BLOCK_CERT_WITH_TIMEOUT, CLIENT_BLOCK_CERT_WITH_TIMEOUT);
+    }
+
+    @SneakyThrows
+    @Test
+    public void getQuorumFinalizationCert() {
+        test(GRPC_BLOCK_CERT_WITH_FINALIZATION, CLIENT_BLOCK_CERT_WITH_FINALIZATION);
+    }
+
+    @Test
+    public void getCertWithAll() {
+        test(GRPC_BLOCK_CERT_WITH_ALL, CLIENT_BLOCK_CERT_WITH_ALL);
+    }
+
+    // Helper method for testing different return values
+    @SneakyThrows
+    private void test(BlockCertificates response, com.concordium.sdk.responses.blockcertificates.BlockCertificates expected) {
+        val serviceImpl = configureResponseAndSetup(response);
+        val res = client.getBlockCertificates(BlockQuery.BEST);
+
+        verify(serviceImpl).getBlockCertificates(any(BlockHashInput.class), any(StreamObserver.class));
+
+        assertEquals(expected, res);
+    }
+
+    // fills a byte[] of length 'len' with 'val' at every pos
+    private static byte[] bytesOfLength(int len, int val) {
+        val buffer = ByteBuffer.allocate(len);
+        Arrays.fill(buffer.array(), (byte) val);
+        return buffer.array();
+    }
+}


### PR DESCRIPTION
## Purpose

Support the new `GetBlockCertificates` query.
## Changes

Added classes: `BlockCertificates`, `EpochFinalizationEntry`, `FinalizerRound`, `QuorumCertificate`, `QuorumSignature`, `SuccessorProof`, `TimeoutCertificate` and `TimeoutSignature`.
Added tests and an example of the implemented method.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
