### PR TITLE
Release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+# Workflow for release a jar file with all native dependencies embedded.
+# The workflow runs whenever a release is published.
+
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # allow manual trigger
+
+env:
+  dummy: 2                 # change to force cache invalidation
+  CARGO_TERM_COLOR: always # implicitly adds '--color=always' to all cargo commands
+
+jobs:
+  build-native-ubuntu:
+    runs-on: ubuntu-22.04
+    
+    steps:
+    # Setup rust
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.69
+        
+    # Checkout the code
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        
+    - name: Make ubuntu native depencies
+      run: make
+
+    - name: Upload linux library
+      uses: actions/upload-artifact@master
+      with:
+        name: ubuntu-library
+        path: ./concordium-sdk/native/libcrypto_jni.so
+
+  build-native-macos:
+    runs-on: macos-latest
+    
+    steps:
+    # Setup rust
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.69
+        
+    # Checkout the code
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        
+    - name: Make macos native depencies
+      run: make
+      
+    - name: Upload macos library
+      uses: actions/upload-artifact@master
+      with:
+        name: macos-library
+        path: ./concordium-sdk/native/libcrypto_jni.dylib
+
+  build-native-windows:
+    runs-on: windows-latest
+    
+    steps:
+    # Setup rust
+    - name: Setup Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.69
+        
+    # Checkout the code
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        
+    - name: Make windows native depencies
+      run: cd crypto-jni && cargo build --release
+      
+    - name: Upload windows library
+      uses: actions/upload-artifact@master
+      with:
+          name: windows-library
+          path: crypto-jni\target\release\crypto_jni.dll
+
+  build-and-release-jar:
+    needs: [build-native-ubuntu, build-native-macos, build-native-windows]
+    # Use fixed OS version because we install packages on the system.
+    runs-on: ubuntu-22.04
+    
+    if: ${{ !github.event.pull_request.draft }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        #token: ${{ secrets.CONCORDIUM_CI }}
+        submodules: recursive
+        
+    - name: Setup JDK 8
+      uses: actions/setup-java@v2
+      with:
+        java-version: 8
+        distribution: 'adopt'
+        cache: maven
+        
+    - name: Download linux library
+      uses: actions/download-artifact@master
+      with:
+        name: ubuntu-library
+        path: concordium-sdk/native
+        
+    - name: Download macos library
+      uses: actions/download-artifact@master
+      with:
+        name: macos-library
+        path: concordium-sdk/native
+
+    - name: Download windows library
+      uses: actions/download-artifact@master
+      with:
+        name: windows-library
+        path: concordium-sdk/native
+
+    # Builds and tests the sdk. Delomboks code and generates a javadoc jar from the delombok'ed code
+    - name: Build and test sdk
+      run: cd concordium-sdk && mvn --batch-mode --update-snapshots install && mvn lombok:delombok -f pom.xml && mvn javadoc:jar -f pom.xml
+
+      # Attach jar files to release (jar, jar-with-dependencies and javadoc-jar)
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: concordium-sdk/target/*.jar
+
+    - name: Deploy javadoc
+      uses: MathieuSoysal/Javadoc-publisher.yml@v2.4.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        javadoc-branch: javadoc
+        java-version: 8
+        target-folder: javadoc # url will be https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/
+        subdirectories: ./concordium-sdk
+        without-checkout: true
+        project: maven
+        custom-command: cd concordium-sdk && mvn javadoc:javadoc -f pom.xml # Generates javadoc from the delombok'ed code
+   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        #token: ${{ secrets.CONCORDIUM_CI }}
         submodules: recursive
         
     - name: Setup JDK 8

--- a/concordium-sdk/.gitignore
+++ b/concordium-sdk/.gitignore
@@ -2,4 +2,4 @@
 *.iml
 /target
 /native/*
-
+/delombok

--- a/concordium-sdk/pom.xml
+++ b/concordium-sdk/pom.xml
@@ -196,6 +196,28 @@
         </extensions>
         <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
             <plugins>
+                <!-- JAVADOC  -->
+                <plugin>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok-maven-plugin</artifactId>
+                    <version>1.18.20.0</version>
+                    <configuration>
+                        <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+                        <outputDirectory>${project.basedir}/delombok</outputDirectory>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.6.0</version>
+                    <configuration>
+                        <doclint>none</doclint>
+                        <author>false</author>
+                        <charset>UTF-8</charset>
+                        <failOnError>false</failOnError>
+                        <sourcepath>${project.basedir}/delombok</sourcepath>
+                    </configuration>
+                </plugin>
                 <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>

--- a/release/README.md
+++ b/release/README.md
@@ -14,6 +14,14 @@ This should set the desired version in the [pom.xml](../concordium-sdk/pom.xml).
 1. Commit and push this new version.
 1. Do a release via Github (the tagged version and the $VERSION just set should be the same)
 1. Set a new `SNAPSHOT` version via:
+
+Publishing the release invokes the `Release` workflow. The `Release` workflow generates and attaches the following to the release.
+1. A jar of the compiled SDK including native dependencies for windows, ubuntu and macos.
+2. A jar-with-dependencies containing all of the above as well as all maven dependencies.
+3. A jar with javadoc that can be imported to the users IDE to add documentation.
+
+Javadoc is also uploaded to ([https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/]https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/)
+
 ```
 mvn versions:set -DnewVersion=$VERSION-SNAPSHOT
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -10,6 +10,7 @@ mvn versions:set -DnewVersion=$VERSION
 ```
 where `$VERSION` is in the following format: `x.y.z`
 This should set the desired version in the [pom.xml](../concordium-sdk/pom.xml).
+The [pom.xml](../concordium-sdk-examples/pom.xml) in [examples](../concordium-sdk-examples) should also be changed to use this new version
 
 1. Commit and push this new version.
 1. Do a release via Github (the tagged version and the $VERSION just set should be the same)
@@ -20,12 +21,12 @@ Publishing the release invokes the `Release` workflow. The `Release` workflow ge
 2. A jar-with-dependencies containing all of the above as well as all maven dependencies.
 3. A jar with javadoc that can be imported to the users IDE to add documentation.
 
-Javadoc is also uploaded to ([https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/]https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/)
+Javadoc is also uploaded to https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/
 
 ```
 mvn versions:set -DnewVersion=$VERSION-SNAPSHOT
 ```
 where `$VERSION` is the just released version.
-
+The [pom.xml](../concordium-sdk-examples/pom.xml) in [examples](../concordium-sdk-examples) should also be changed to use this new snapshot version
 1. Commit and push the `SNAPSHOT` version.
 


### PR DESCRIPTION
## Purpose

Adds a workflow automatically compiling native dependencies and attaching a jar with the dependencies embedded to new releases when created. Also generates javadoc both as a .jar attached to the release and as a "site" deployed to https://concordium.github.io/concordium-java-sdk/javadoc/concordium-sdk/apidocs/

Result of release demonstrated as release in https://github.com/magnusbechwind/concordium-java-sdk/releases/tag/v.5.1.2

## Changes

Added workflow and updated the pom

In addition to the proposed changes, the settings/pages should be changed to the following to enable deplayment of javadoc 
<img width="697" alt="image" src="https://github.com/Concordium/concordium-java-sdk/assets/93247743/16dd7630-cfcc-41f7-b980-29078bf1729f">

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
