### PR TITLE
Support new endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+- Added support for GRPC V2 `GetWinningBakersEpoch` for getting a list of bakers that won the lottery in a particular historical epoch. Only available when querying a node with version at least 6.1.
+- Added support for GRPC V2 `GetFirstBlockEpoch` for getting the block hash of the first finalized block in a specified epoch. Only available when querying a node with version at least 6.1.
+- Added support for GRPC V2 `GetBakerEarliestWinTime` for getting the projected earliest time at which a particular baker will be required to bake a block. Only available when querying a node woth version at least 6.1.
 - Added support for GRPC V2 `GetBakerRewardPeriodInfo` for getting all the bakers in the reward period of a block. Only available when querying a node with version at least 6.1.
 - Added support for GRPC V2 `GetBlockCertificates` for retrieving certificates for a block supporting ConcordiumBF, i.e. a node with at least version 6.1.
 - Extended `CurrentPaydayStatus` with `CommissionRates` that apply for the current reward period. Requires at least node version 6.1.

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetBakerEarliestWinTime.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetBakerEarliestWinTime.java
@@ -1,0 +1,42 @@
+package com.concordium.sdk.examples;
+
+import com.concordium.sdk.ClientV2;
+import com.concordium.sdk.Connection;
+import com.concordium.sdk.responses.BakerId;
+import com.concordium.sdk.types.Timestamp;
+import picocli.CommandLine;
+
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+/**
+ * Creates a {@link ClientV2} from the specified connection ("http://localhost:20002" if not specified).
+ * Retrieves and prints the {@link Timestamp} of the projected earliest time at which baker with id = 1 will be required to bake a block.
+ */
+@CommandLine.Command(name = "GetBakerEarliestWinTime", mixinStandardHelpOptions = true)
+public class GetBakerEarliestWinTime implements Callable<Integer> {
+    @CommandLine.Option(
+            names = {"--endpoint"},
+            description = "GRPC interface of the node.",
+            defaultValue = "http://localhost:20002")
+    private String endpoint;
+
+    @Override
+    public Integer call() throws Exception {
+        URL endpointUrl = new URL(this.endpoint);
+        Connection connection = Connection.newBuilder()
+                .host(endpointUrl.getHost())
+                .port(endpointUrl.getPort())
+                .build();
+
+        ClientV2 client = ClientV2.from(connection);
+        Timestamp timestamp = client.getBakerEarliestWinTime(BakerId.from(1));
+        System.out.println(timestamp);
+        return 0;
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new GetBakerEarliestWinTime()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetFirstBlockEpoch.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetFirstBlockEpoch.java
@@ -1,0 +1,43 @@
+package com.concordium.sdk.examples;
+
+import com.concordium.sdk.ClientV2;
+import com.concordium.sdk.Connection;
+import com.concordium.sdk.requests.EpochQuery;
+import com.concordium.sdk.responses.Epoch;
+import com.concordium.sdk.transactions.Hash;
+import picocli.CommandLine;
+
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+/**
+ * Creates a {@link ClientV2} from the specified connection ("http://localhost:20002" if not specified).
+ * Retrieves and prints the {@link Hash} of the first finalized block for the Epoch 2 at genesis index 5.
+ */
+@CommandLine.Command(name = "GetFirstBlockEpoch", mixinStandardHelpOptions = true)
+public class GetFirstBlockEpoch implements Callable<Integer> {
+    @CommandLine.Option(
+            names = {"--endpoint"},
+            description = "GRPC interface of the node.",
+            defaultValue = "http://localhost:20002")
+    private String endpoint;
+
+    @Override
+    public Integer call() throws Exception {
+        URL endpointUrl = new URL(this.endpoint);
+        Connection connection = Connection.newBuilder()
+                .host(endpointUrl.getHost())
+                .port(endpointUrl.getPort())
+                .build();
+
+        ClientV2 client = ClientV2.from(connection);
+        Hash hash = client.getFirstBlockEpoch(EpochQuery.RELATIVE_EPOCH(5, Epoch.from(2)));
+        System.out.println(hash);
+        return 0;
+    }
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new GetFirstBlockEpoch()).execute(args);
+        System.exit(exitCode);
+    }
+}

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetFirstBlockEpoch.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetFirstBlockEpoch.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable;
 
 /**
  * Creates a {@link ClientV2} from the specified connection ("http://localhost:20002" if not specified).
- * Retrieves and prints the {@link Hash} of the first finalized block for the Epoch 2 at genesis index 5.
+ * Retrieves and prints the {@link Hash} of the first finalized block for specified Epoch at the specified genesis index (Epoch 2 at genesis index 5 if not specified).
  */
 @CommandLine.Command(name = "GetFirstBlockEpoch", mixinStandardHelpOptions = true)
 public class GetFirstBlockEpoch implements Callable<Integer> {
@@ -21,6 +21,18 @@ public class GetFirstBlockEpoch implements Callable<Integer> {
             description = "GRPC interface of the node.",
             defaultValue = "http://localhost:20002")
     private String endpoint;
+
+    @CommandLine.Option(
+            names = {"--genesisIndex"},
+            description = "Genesis index to query at",
+            defaultValue = "5")
+    private int genesisIndex;
+
+    @CommandLine.Option(
+            names = {"--epoch"},
+            description = "Epoch index to query",
+            defaultValue = "5")
+    private int epoch;
 
     @Override
     public Integer call() throws Exception {
@@ -31,7 +43,7 @@ public class GetFirstBlockEpoch implements Callable<Integer> {
                 .build();
 
         ClientV2 client = ClientV2.from(connection);
-        Hash hash = client.getFirstBlockEpoch(EpochQuery.RELATIVE_EPOCH(5, Epoch.from(2)));
+        Hash hash = client.getFirstBlockEpoch(EpochQuery.RELATIVE_EPOCH(genesisIndex, Epoch.from(epoch)));
         System.out.println(hash);
         return 0;
     }

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetWinningBakersEpoch.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetWinningBakersEpoch.java
@@ -1,23 +1,25 @@
 package com.concordium.sdk.examples;
 
+import com.concordium.grpc.v2.WinningBaker;
 import com.concordium.sdk.ClientV2;
 import com.concordium.sdk.Connection;
-import com.concordium.sdk.responses.peerlist.PeerInfo;
+import com.concordium.sdk.requests.EpochQuery;
+import com.concordium.sdk.responses.Epoch;
 import picocli.CommandLine;
 
 import java.net.URL;
 import java.util.concurrent.Callable;
 
 /**
- * Creates a {@link ClientV2} from the specified connection ("http://localhost:20000" if not specified).
- * Retrieves and prints the {@link PeerInfo} of connected Peers.
+ * Creates a {@link ClientV2} from the specified connection ("http://localhost:20002" if not specified).
+ * Retrieves and prints the {@link WinningBaker}s for the Epoch 2 at genesis index 5.
  */
-@CommandLine.Command(name = "GetPeersInfo", mixinStandardHelpOptions = true)
-public class GetPeersInfo implements Callable<Integer> {
+@CommandLine.Command(name = "GetWinningBakersEpoch", mixinStandardHelpOptions = true)
+public class GetWinningBakersEpoch implements Callable<Integer> {
     @CommandLine.Option(
             names = {"--endpoint"},
             description = "GRPC interface of the node.",
-            defaultValue = "http://localhost:20000")
+            defaultValue = "http://localhost:20002")
     private String endpoint;
 
     @Override
@@ -28,16 +30,15 @@ public class GetPeersInfo implements Callable<Integer> {
                 .port(endpointUrl.getPort())
                 .build();
 
-        ClientV2
-                .from(connection)
-                .getPeersInfo()
+        ClientV2 client = ClientV2.from(connection);
+        client.getWinningBakersEpoch(EpochQuery.RELATIVE_EPOCH(5, Epoch.from(2)))
                 .forEach(System.out::println);
 
         return 0;
     }
 
     public static void main(String[] args) {
-        int exitCode = new CommandLine(new GetPeersInfo()).execute(args);
+        int exitCode = new CommandLine(new GetWinningBakersEpoch()).execute(args);
         System.exit(exitCode);
     }
 }

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetWinningBakersEpoch.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/GetWinningBakersEpoch.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable;
 
 /**
  * Creates a {@link ClientV2} from the specified connection ("http://localhost:20002" if not specified).
- * Retrieves and prints the {@link WinningBaker}s for the Epoch 2 at genesis index 5.
+ * Retrieves and prints the {@link WinningBaker}s for the first finalized block for specified Epoch at the specified genesis index (Epoch 2 at genesis index 5 if not specified).
  */
 @CommandLine.Command(name = "GetWinningBakersEpoch", mixinStandardHelpOptions = true)
 public class GetWinningBakersEpoch implements Callable<Integer> {
@@ -21,6 +21,18 @@ public class GetWinningBakersEpoch implements Callable<Integer> {
             description = "GRPC interface of the node.",
             defaultValue = "http://localhost:20002")
     private String endpoint;
+
+    @CommandLine.Option(
+            names = {"--genesisIndex"},
+            description = "Genesis index to query at",
+            defaultValue = "5")
+    private int genesisIndex;
+
+    @CommandLine.Option(
+            names = {"--epoch"},
+            description = "Epoch index to query",
+            defaultValue = "5")
+    private int epoch;
 
     @Override
     public Integer call() throws Exception {
@@ -31,7 +43,7 @@ public class GetWinningBakersEpoch implements Callable<Integer> {
                 .build();
 
         ClientV2 client = ClientV2.from(connection);
-        client.getWinningBakersEpoch(EpochQuery.RELATIVE_EPOCH(5, Epoch.from(2)))
+        client.getWinningBakersEpoch(EpochQuery.RELATIVE_EPOCH(genesisIndex, Epoch.from(epoch)))
                 .forEach(System.out::println);
 
         return 0;

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -4,6 +4,7 @@ import com.concordium.grpc.v2.*;
 import com.concordium.sdk.exceptions.ClientInitializationException;
 import com.concordium.sdk.requests.AccountQuery;
 import com.concordium.sdk.requests.BlockQuery;
+import com.concordium.sdk.requests.EpochQuery;
 import com.concordium.sdk.requests.dumpstart.DumpRequest;
 import com.concordium.sdk.requests.smartcontracts.InvokeInstanceRequest;
 import com.concordium.sdk.responses.AccountIndex;
@@ -31,12 +32,14 @@ import com.concordium.sdk.responses.peerlist.PeerInfo;
 import com.concordium.sdk.responses.poolstatus.BakerPoolStatus;
 import com.concordium.sdk.responses.rewardstatus.RewardsOverview;
 import com.concordium.sdk.responses.smartcontracts.InvokeInstanceResult;
+import com.concordium.sdk.responses.winningbaker.WinningBaker;
 import com.concordium.sdk.transactions.AccountTransaction;
 import com.concordium.sdk.transactions.BlockItem;
 import com.concordium.sdk.transactions.*;
 import com.concordium.sdk.transactions.smartcontracts.WasmModule;
 import com.concordium.sdk.types.AccountAddress;
 import com.concordium.sdk.types.ContractAddress;
+import com.concordium.sdk.types.Timestamp;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import io.grpc.ManagedChannel;
@@ -786,6 +789,74 @@ public final class ClientV2 {
     public BlockCertificates getBlockCertificates(BlockQuery block) {
         val res = this.server().getBlockCertificates(to(block));
         return BlockCertificates.from(res);
+    }
+
+    /**
+     * Get the projected earliest time at which a particular baker will be required to bake a block. <p>
+     * If the current consensus version is 0, then an 'UNIMPLEMENTED' exception will be thrown, as the endpoint
+     * is only supported by consensus version 1.<p>
+     *
+     * If the baker is not a baker for the current reward period, this returns a timestamp at the
+     * start of the next reward period. <p>
+     * If the baker is a baker for the current reward period, the
+     * earliest win time is projected from the current round forward, assuming that each round after
+     * the last finalized round will take the minimum block time. (If blocks take longer, or timeouts
+     * occur, the actual time may be later, and the reported time in subsequent queries may reflect
+     * this.) <p>
+     * At the end of an epoch (or if the baker is not projected to bake before the end of the
+     * epoch) the earliest win time for a (current) baker will be projected as the start of the next
+     * epoch. This is because the seed for the leader election is updated at the epoch boundary, and
+     * so the winners cannot be predicted beyond that. <p>
+     * Note that in some circumstances the returned timestamp can be in the past, especially at the end of an epoch.
+     * @param bakerId id of the baker to query.
+     * @return {@link Timestamp} as described in the method documentation.
+     */
+    public Timestamp getBakerEarliestWinTime(BakerId bakerId) {
+        val res = this.server().getBakerEarliestWinTime(to(bakerId));
+        return Timestamp.from(res);
+    }
+
+    /**
+     * Get the block hash of the first finalized block in a specified epoch. <p>
+     * The following error cases are possible:
+     * <ul>
+     * <li> 'NOT_FOUND' if the query specifies an unknown block.
+     * <li> 'UNAVAILABLE' if the query is for an epoch that is not finalized in the current genesis index, or is for a future genesis index.
+     * <li> 'INVALID_ARGUMENT' if the query is for an epoch with no finalized blocks for a past genesis index.
+     * <li> 'INVALID_ARGUMENT' if the input {@link EpochQuery} is malformed.
+     * <li> 'UNIMPLEMENTED' if the endpoint is disabled on the node.
+     * </ul>
+     * @param epochQuery {@link EpochQuery} representing the specific epoch to query.
+     * @return {@link Hash} of the first finalized block in the epoch.
+     */
+    public Hash getFirstBlockEpoch(EpochQuery epochQuery) {
+        val res = this.server().getFirstBlockEpoch(to(epochQuery));
+        return Hash.from(res);
+    }
+
+    /**
+     * Get the list of bakers that won the lottery in a particular historical epoch (i.e. the last finalized block is in a later epoch). <p>
+     * This lists the winners for each round in the epoch, starting from the round after the last block in the previous epoch, running to the round before the first block in the next epoch. <p>
+     * It also indicates if a block in each round was included in the finalized chain. <p>
+     * The following error cases are possible:
+     * <ul>
+     * <li> 'NOT_FOUND' if the query specifies an unknown block.
+     * <li> 'UNAVAILABLE' if the query is for an epoch that is not finalized in the current genesis index, or is for a future genesis index.
+     * <li> 'INVALID_ARGUMENT' if the query is for an epoch that is not finalized for a past genesis index.
+     * <li> 'INVALID_ARGUMENT' if the query is for a genesis index at consensus version 0.
+     * <li> 'INVALID_ARGUMENT' if the input {@link EpochQuery} is malformed.
+     * <li> 'UNIMPLEMENTED' if the endpoint is disabled on the node.
+     * </ul>
+     * @param epochQuery {@link EpochQuery} representing the specific epoch to query.
+     * @return {@link ImmutableList} of bakers that won the lottery in the specified epoch.
+     */
+    public ImmutableList<WinningBaker> getWinningBakersEpoch(EpochQuery epochQuery) {
+        val res = this.server().getWinningBakersEpoch(to(epochQuery));
+        val winners = new ImmutableList.Builder<WinningBaker>();
+        res.forEachRemaining(
+                winner -> winners.add(WinningBaker.parse(winner))
+        );
+        return winners.build();
     }
 
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -793,8 +793,6 @@ public final class ClientV2 {
 
     /**
      * Get the projected earliest time at which a particular baker will be required to bake a block. <p>
-     * If the current consensus version is 0, then an 'UNIMPLEMENTED' exception will be thrown, as the endpoint
-     * is only supported by consensus version 1.<p>
      *
      * If the baker is not a baker for the current reward period, this returns a timestamp at the
      * start of the next reward period. <p>
@@ -810,6 +808,8 @@ public final class ClientV2 {
      * Note that in some circumstances the returned timestamp can be in the past, especially at the end of an epoch.
      * @param bakerId id of the baker to query.
      * @return {@link Timestamp} as described in the method documentation.
+     * @throws io.grpc.StatusRuntimeException with {@link io.grpc.Status.Code}:
+     * <ul><li>{@link io.grpc.Status.Code#UNIMPLEMENTED} if the current consensus version is 0, as the endpoint is only supported by consensus version 1.</ul>
      */
     public Timestamp getBakerEarliestWinTime(BakerId bakerId) {
         val res = this.server().getBakerEarliestWinTime(to(bakerId));
@@ -817,17 +817,17 @@ public final class ClientV2 {
     }
 
     /**
-     * Get the block hash of the first finalized block in a specified epoch. <p>
-     * The following error cases are possible:
-     * <ul>
-     * <li> 'NOT_FOUND' if the query specifies an unknown block.
-     * <li> 'UNAVAILABLE' if the query is for an epoch that is not finalized in the current genesis index, or is for a future genesis index.
-     * <li> 'INVALID_ARGUMENT' if the query is for an epoch with no finalized blocks for a past genesis index.
-     * <li> 'INVALID_ARGUMENT' if the input {@link EpochQuery} is malformed.
-     * <li> 'UNIMPLEMENTED' if the endpoint is disabled on the node.
-     * </ul>
+     * Get the block hash of the first finalized block in a specified epoch.
+     *
      * @param epochQuery {@link EpochQuery} representing the specific epoch to query.
      * @return {@link Hash} of the first finalized block in the epoch.
+     * @throws io.grpc.StatusRuntimeException with {@link io.grpc.Status.Code}: <ul>
+     * <li> {@link io.grpc.Status#NOT_FOUND} if the query specifies an unknown block.
+     * <li> {@link io.grpc.Status#UNAVAILABLE} if the query is for an epoch that is not finalized in the current genesis index, or is for a future genesis index.
+     * <li> {@link io.grpc.Status#INVALID_ARGUMENT} if the query is for an epoch with no finalized blocks for a past genesis index.
+     * <li> {@link io.grpc.Status#INVALID_ARGUMENT} if the input {@link EpochQuery} is malformed.
+     * <li> {@link io.grpc.Status#UNIMPLEMENTED} if the endpoint is disabled on the node.
+     * </ul>
      */
     public Hash getFirstBlockEpoch(EpochQuery epochQuery) {
         val res = this.server().getFirstBlockEpoch(to(epochQuery));
@@ -837,18 +837,17 @@ public final class ClientV2 {
     /**
      * Get the list of bakers that won the lottery in a particular historical epoch (i.e. the last finalized block is in a later epoch). <p>
      * This lists the winners for each round in the epoch, starting from the round after the last block in the previous epoch, running to the round before the first block in the next epoch. <p>
-     * It also indicates if a block in each round was included in the finalized chain. <p>
-     * The following error cases are possible:
-     * <ul>
-     * <li> 'NOT_FOUND' if the query specifies an unknown block.
-     * <li> 'UNAVAILABLE' if the query is for an epoch that is not finalized in the current genesis index, or is for a future genesis index.
-     * <li> 'INVALID_ARGUMENT' if the query is for an epoch that is not finalized for a past genesis index.
-     * <li> 'INVALID_ARGUMENT' if the query is for a genesis index at consensus version 0.
-     * <li> 'INVALID_ARGUMENT' if the input {@link EpochQuery} is malformed.
-     * <li> 'UNIMPLEMENTED' if the endpoint is disabled on the node.
-     * </ul>
+     * It also indicates if a block in each round was included in the finalized chain.
      * @param epochQuery {@link EpochQuery} representing the specific epoch to query.
      * @return {@link ImmutableList} of bakers that won the lottery in the specified epoch.
+     * @throws io.grpc.StatusRuntimeException with {@link io.grpc.Status.Code}: <ul>
+     * <li> {@link io.grpc.Status#NOT_FOUND} if the query specifies an unknown block.
+     * <li> {@link io.grpc.Status#UNAVAILABLE} if the query is for an epoch that is not finalized in the current genesis index, or is for a future genesis index.
+     * <li> {@link io.grpc.Status#INVALID_ARGUMENT} if the query is for an epoch that is not finalized for a past genesis index.
+     * <li> {@link io.grpc.Status#INVALID_ARGUMENT} if the query is for a genesis index at consensus version 0.
+     * <li> {@link io.grpc.Status#INVALID_ARGUMENT} if the input {@link EpochQuery} is malformed.
+     * <li> {@link io.grpc.Status#UNIMPLEMENTED} if the endpoint is disabled on the node.
+     * </ul>
      */
     public ImmutableList<WinningBaker> getWinningBakersEpoch(EpochQuery epochQuery) {
         val res = this.server().getWinningBakersEpoch(to(epochQuery));

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -784,11 +784,11 @@ public final class ClientV2 {
     /**
      * Get all bakers in the reward period of a block.
      * This endpoint is only supported for protocol version 6 and onwards.
-     * If the protocol does not support the endpoint then an 'UNIMPLEMENTED' exception is thrown
      *
      * @param input The block to query.
-     *
      * @return {@link ImmutableList} with the {@link BakerRewardPeriodInfo} of all the bakers in the block.
+     * @throws io.grpc.StatusRuntimeException with {@link io.grpc.Status.Code}:
+     * <ul><li>{@link io.grpc.Status.Code#UNIMPLEMENTED} if the protocol does not support the endpoint.</ul>
      */
     public ImmutableList<BakerRewardPeriodInfo> getBakersRewardPeriod(BlockQuery input) {
         val response = this.server().getBakersRewardPeriod(to(input));
@@ -801,10 +801,13 @@ public final class ClientV2 {
 
     /**
      * Retrieves the {@link BlockCertificates} for a given block.
-     * Note that, if the block being pointed to is not a product of ConcordiumBFT, i.e. created before protocol version 6, then a INVALID_ARGUMENT exception will be thrown.
-     * If the endpoint is not enabled by the node, then an 'UNIMPLEMENTED' exception will be thrown.
+     *
      * @param block The block to query
      * @return {@link BlockCertificates} of the block.
+     * @throws io.grpc.StatusRuntimeException with {@link io.grpc.Status.Code}:<ul>
+     * <li>{@link io.grpc.Status.Code#UNIMPLEMENTED} if the endpoint is not enabled by the node.
+     * <li>{@link io.grpc.Status.Code#INVALID_ARGUMENT} if the block being pointed to is not a product of ConcordiumBFT, i.e. created before protocol version 6.
+     * </ul>
      */
     public BlockCertificates getBlockCertificates(BlockQuery block) {
         val res = this.server().getBlockCertificates(to(block));

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
@@ -31,6 +31,7 @@ import com.concordium.sdk.crypto.pointchevalsanders.PSPublicKey;
 import com.concordium.sdk.crypto.vrf.VRFPublicKey;
 import com.concordium.sdk.requests.AccountQuery;
 import com.concordium.sdk.requests.BlockQuery;
+import com.concordium.sdk.requests.EpochQuery;
 import com.concordium.sdk.responses.Epoch;
 import com.concordium.sdk.responses.Round;
 import com.concordium.sdk.responses.TimeoutParameters;
@@ -1644,5 +1645,23 @@ interface ClientV2MapperExtensions {
         return com.concordium.grpc.v2.Parameter.newBuilder()
                 .setValue(ByteString.copyFrom(parameter.getBytes()))
                 .build();
+    }
+
+    static EpochRequest to(EpochQuery query) {
+        switch (query.getType()) {
+            case BLOCK_HASH:
+                return EpochRequest.newBuilder()
+                        .setBlockHash(to(query.getBlockHashInput())).build();
+            case RELATIVE_EPOCH:
+                return EpochRequest.newBuilder()
+                        .setRelativeEpoch(
+                                EpochRequest.RelativeEpoch.newBuilder()
+                                        .setGenesisIndex(GenesisIndex.newBuilder().setValue(query.getGenesisIndex()).build())
+                                        .setEpoch(com.concordium.grpc.v2.Epoch.newBuilder().setValue(query.getEpoch().getValue().getValue()).build())
+                                        .build()
+                        ).build();
+            default:
+                throw new IllegalArgumentException("Unexpected EpochQuery");
+        }
     }
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/requests/EpochQuery.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/requests/EpochQuery.java
@@ -1,0 +1,70 @@
+package com.concordium.sdk.requests;
+
+import com.concordium.sdk.responses.Epoch;
+import lombok.*;
+
+import javax.annotation.Nullable;
+
+/**
+ * Input to queries that take an {@link Epoch} as a parameter.
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public class EpochQuery {
+
+    /**
+     * Query for the epoch of a specified block.
+     * @param block the specific block to query.
+     */
+    public static EpochQuery BLOCK_HASH(BlockQuery block) {
+        return EpochQuery.builder()
+            .blockHashInput(block)
+            .type(EpochQueryType.BLOCK_HASH).build();
+    }
+
+    /**
+     * Query by genesis index and epoch.
+     * @param genesisIndex the genesis index to query at. The query is restricted to this genesis index, and will not return results for other indices even if the epoch number is out of bounds.
+     * @param epoch the {@link Epoch} to query at.
+     */
+    public static EpochQuery RELATIVE_EPOCH(int genesisIndex, Epoch epoch) {
+        return EpochQuery.builder()
+                .type(EpochQueryType.RELATIVE_EPOCH)
+                .genesisIndex(genesisIndex)
+                .epoch(epoch).build();
+    }
+
+    /**
+     * Type of {@link EpochQuery}
+     */
+    @Getter
+    @NonNull
+    private final EpochQueryType type;
+
+    /**
+     * Block with epoch to query. Will only be set if the type is {@link EpochQueryType#BLOCK_HASH}
+     */
+    @Getter
+    @Nullable
+    private final BlockQuery blockHashInput;
+
+
+    /**
+     * Epoch to query. Will only be set if the type is {@link EpochQueryType#RELATIVE_EPOCH}
+     */
+    @Getter
+    @Nullable
+    private final Epoch epoch;
+
+
+    /**
+     * Genesis index to query at. Will only be set if the type is {@link EpochQueryType#RELATIVE_EPOCH}
+     */
+    @Getter
+    private final int genesisIndex;
+
+
+    public enum EpochQueryType {
+        BLOCK_HASH,
+        RELATIVE_EPOCH
+    }
+}

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/winningbaker/WinningBaker.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/winningbaker/WinningBaker.java
@@ -24,7 +24,7 @@ public class WinningBaker {
      */
     private final BakerId winner;
     /**
-     * True if the baker produced a block in this round on the finalized chain, and False otherwise.
+     * True if the block is present on the finalized chain.
      */
     private final boolean present;
 

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/winningbaker/WinningBaker.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/winningbaker/WinningBaker.java
@@ -15,9 +15,17 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class WinningBaker {
-
+    /**
+     * The round number.
+     */
     private final Round round;
+    /**
+     * The baker that won the round.
+     */
     private final BakerId winner;
+    /**
+     * True if the baker produced a block in this round on the finalized chain, and False otherwise.
+     */
     private final boolean present;
 
     /**

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/winningbaker/WinningBaker.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/winningbaker/WinningBaker.java
@@ -1,0 +1,35 @@
+package com.concordium.sdk.responses.winningbaker;
+
+import com.concordium.sdk.responses.BakerId;
+import com.concordium.sdk.responses.Round;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Details of which baker won the lottery in a given round in consensus version 1.
+ */
+@Getter
+@Builder
+@EqualsAndHashCode
+@ToString
+public class WinningBaker {
+
+    private final Round round;
+    private final BakerId winner;
+    private final boolean present;
+
+    /**
+     * Parses {@link com.concordium.grpc.v2.WinningBaker} to {@link WinningBaker}.
+     * @param winner {@link com.concordium.grpc.v2.WinningBaker} returned by the GRPC V2 API.
+     * @return parsed {@link WinningBaker}.
+     */
+    public static WinningBaker parse(com.concordium.grpc.v2.WinningBaker winner) {
+        return WinningBaker.builder()
+                .round(Round.from(winner.getRound()))
+                .winner(BakerId.from(winner.getWinner()))
+                .present(winner.getPresent())
+                .build();
+    }
+}

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetWinningBakersEpochTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetWinningBakersEpochTest.java
@@ -95,7 +95,7 @@ public class ClientV2GetWinningBakersEpochTest {
     }
 
     @Test
-    public void getModuleList() {
+    public void getWinningBakersEpoch() {
         var query = EpochQuery.BLOCK_HASH(BlockQuery.BEST);
         var res = client.getWinningBakersEpoch(query);
 

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetWinningBakersEpochTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetWinningBakersEpochTest.java
@@ -1,0 +1,105 @@
+package com.concordium.sdk;
+
+import com.concordium.grpc.v2.*;
+import com.concordium.sdk.requests.BlockQuery;
+import com.concordium.sdk.requests.EpochQuery;
+import com.google.common.collect.ImmutableList;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import lombok.var;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ *
+ */
+public class ClientV2GetWinningBakersEpochTest {
+
+    // ----- Test Values -----
+    private static final boolean PRESENT_1 = true;
+    private static final boolean PRESENT_2 = false;
+    private static final long WINNER_1 = 1;
+    private static final long WINNER_2 = 2;
+    private static final long ROUND_1 = 1;
+    private static final long ROUND_2 = 2;
+
+
+
+    // ----- Client Values -----
+    private static final com.concordium.sdk.responses.winningbaker.WinningBaker CLIENT_WINNING_BAKER_1 = com.concordium.sdk.responses.winningbaker.WinningBaker.builder()
+            .round(com.concordium.sdk.responses.Round.from(ROUND_1))
+            .winner(com.concordium.sdk.responses.BakerId.from(WINNER_1))
+            .present(PRESENT_1)
+            .build();
+    private static final com.concordium.sdk.responses.winningbaker.WinningBaker CLIENT_WINNING_BAKER_2 = com.concordium.sdk.responses.winningbaker.WinningBaker.builder()
+            .round(com.concordium.sdk.responses.Round.from(ROUND_2))
+            .winner(com.concordium.sdk.responses.BakerId.from(WINNER_2))
+            .present(PRESENT_2)
+            .build();
+
+    // ----- GRPC Values -----
+    private static final EpochRequest GRPC_REQUEST = EpochRequest.newBuilder()
+            .setBlockHash(
+                    BlockHashInput.newBuilder().setBest(Empty.newBuilder().build())
+            )
+            .build();
+    private static final WinningBaker GRPC_WINNING_BAKER_1 = WinningBaker.newBuilder()
+            .setRound(Round.newBuilder().setValue(ROUND_1))
+            .setWinner(BakerId.newBuilder().setValue(WINNER_1))
+            .setPresent(PRESENT_1)
+            .build();
+    private static final WinningBaker GRPC_WINNING_BAKER_2 = WinningBaker.newBuilder()
+            .setRound(Round.newBuilder().setValue(ROUND_2))
+            .setWinner(BakerId.newBuilder().setValue(WINNER_2))
+            .setPresent(PRESENT_2)
+            .build();
+    private static final QueriesGrpc.QueriesImplBase serviceImpl = mock(QueriesGrpc.QueriesImplBase.class, delegatesTo(
+            new QueriesGrpc.QueriesImplBase() {
+                @Override
+                public void getWinningBakersEpoch(
+                        com.concordium.grpc.v2.EpochRequest request,
+                        StreamObserver<WinningBaker> responseObserver) {
+                    responseObserver.onNext(GRPC_WINNING_BAKER_1);
+                    responseObserver.onNext(GRPC_WINNING_BAKER_2);
+                    responseObserver.onCompleted();
+                }
+            }
+    ));
+
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+    private ClientV2 client;
+
+    @Before
+    public void setUp() throws Exception {
+        String serverName = InProcessServerBuilder.generateName();
+        grpcCleanup.register(InProcessServerBuilder
+                .forName(serverName).directExecutor().addService(serviceImpl).build().start());
+        ManagedChannel channel = grpcCleanup.register(
+                InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        client = new ClientV2(10000, channel, Optional.empty());
+    }
+
+    @Test
+    public void getModuleList() {
+        var query = EpochQuery.BLOCK_HASH(BlockQuery.BEST);
+        var res = client.getWinningBakersEpoch(query);
+
+        verify(serviceImpl).getWinningBakersEpoch(eq(GRPC_REQUEST), any(StreamObserver.class));
+        assertEquals(ImmutableList.copyOf(res), ImmutableList.of(CLIENT_WINNING_BAKER_1, CLIENT_WINNING_BAKER_2));
+    }
+}

--- a/crypto-jni/Cargo.lock
+++ b/crypto-jni/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.0.0"
+version = "8.1.0"
 dependencies = [
  "base64",
  "bs58",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "2.0.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bs58",


### PR DESCRIPTION
## Purpose

Support the new queries `GetWinningBakersEpoch`, `GetFirstBlockEpoch` and  `GetBakerEarliestWinTime`.

## Changes

Added new class `EpochQuery` to represent the GRPC `EpochRequest`. Added the above calls to `ClientV2`

Changed documentation of unreleased `GetBakersRewardPeriod` and `GetBlockCertificates` to be consistent with the methods added here.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
