### PR TITLE
Fix expiry type

### DIFF
--- a/concordium-android-sdk/pom.xml
+++ b/concordium-android-sdk/pom.xml
@@ -188,7 +188,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${basedir}/../concordium-android-sdk-examples/app/libs</outputDirectory>
+                            <outputDirectory>${basedir}/../concordium-android-wallet-example/app/libs</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}/target</directory>

--- a/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/activities/IdentityActivity.kt
+++ b/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/activities/IdentityActivity.kt
@@ -28,6 +28,8 @@ import com.concordium.example.wallet.Requests
 import com.concordium.example.wallet.Storage
 import com.concordium.example.wallet.services.ConcordiumClientService
 import com.concordium.example.wallet.ui.Container
+import com.concordium.sdk.transactions.CredentialDeploymentTransaction
+import com.concordium.sdk.transactions.Expiry
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.apache.commons.codec.binary.Hex
 import java.util.Collections
@@ -55,7 +57,7 @@ class IdentityActivity : ComponentActivity() {
             ipIdentity,
         )
 
-        val expiry = TransactionExpiry.fromLong(Date().time + 360)
+        val expiry = Expiry.createNew().addMinutes(5)
 
         val credentialDeploymentSignDigest = Credential.getCredentialDeploymentSignDigest(
             CredentialDeploymentDetails(
@@ -74,8 +76,9 @@ class IdentityActivity : ComponentActivity() {
             Collections.singletonMap(Index.from(0), Hex.encodeHexString(signature))
         )
         val credentialPayload = Credential.serializeCredentialDeploymentPayload(context)
+        val credentialDeploymentTransaction = CredentialDeploymentTransaction.from(expiry, credentialPayload)
         ConcordiumClientService.getClient()
-            .sendCredentialDeploymentTransaction(expiry, credentialPayload)
+            .sendCredentialDeploymentTransaction(credentialDeploymentTransaction)
 
         // Save the address of the account
         val address =

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2.java
@@ -238,8 +238,8 @@ public final class ClientV2 {
      * @param rawPayload the serialized bytes of the credential deployment transaction, including its signatures
      * @return Transaction {@link Hash}.
      */
-    public Hash sendCredentialDeploymentTransaction(TransactionExpiry expiry, byte[] rawPayload) {
-        val req = ClientV2MapperExtensions.to(expiry, rawPayload);
+    public Hash sendCredentialDeploymentTransaction(CredentialDeploymentTransaction credentialDeploymentTransaction) {
+        val req = ClientV2MapperExtensions.to(credentialDeploymentTransaction);
         val grpcOutput = this.server().sendBlockItem(req);
 
         return to(grpcOutput);

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
@@ -77,7 +77,6 @@ import com.concordium.sdk.transactions.Signature;
 import com.concordium.sdk.transactions.TransferPayload;
 import com.concordium.sdk.transactions.TransferWithMemoPayload;
 import com.concordium.sdk.transactions.*;
-import com.concordium.sdk.transactions.UpdateContract;
 import com.concordium.sdk.transactions.smartcontracts.WasmModule;
 import com.concordium.sdk.transactions.smartcontracts.WasmModuleVersion;
 import com.concordium.sdk.types.Timestamp;
@@ -871,14 +870,14 @@ interface ClientV2MapperExtensions {
                 .build();
     }
 
-    static SendBlockItemRequest to(TransactionExpiry expiry, byte[] payload) {
-        TransactionTime time = to(expiry.getExpiry());
+    static SendBlockItemRequest to(CredentialDeploymentTransaction credentialDeploymentTransaction) {
+        TransactionTime time = to(credentialDeploymentTransaction.getExpiry().getValue());
 
         return SendBlockItemRequest.newBuilder()
             .setCredentialDeployment(
                 CredentialDeployment.newBuilder()
                     .setMessageExpiry(time)
-                    .setRawPayload(ByteString.copyFrom(payload))
+                    .setRawPayload(ByteString.copyFrom(credentialDeploymentTransaction.getPayloadBytes()))
                     .build()
                 )
             .build();

--- a/concordium-sdk/src/main/java/com/concordium/sdk/crypto/wallet/credential/CredentialDeploymentDetails.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/crypto/wallet/credential/CredentialDeploymentDetails.java
@@ -1,6 +1,6 @@
 package com.concordium.sdk.crypto.wallet.credential;
 
-import com.concordium.sdk.transactions.TransactionExpiry;
+import com.concordium.sdk.transactions.Expiry;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import lombok.AllArgsConstructor;
@@ -16,6 +16,6 @@ public class CredentialDeploymentDetails {
     
     @NonNull
     @JsonUnwrapped
-    private final TransactionExpiry expiry;
+    private final Expiry expiry;
     
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialDeploymentTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/CredentialDeploymentTransaction.java
@@ -50,6 +50,19 @@ public class CredentialDeploymentTransaction extends BlockItem {
                 Arrays.copyOf(payloadBytes, payloadBytes.length));
     }
 
+    /**
+     * Creates an instance of {@link CredentialDeploymentTransaction}.
+     *
+     * @param expiry       Indicates when this transaction should expire.
+     * @param payloadBytes Payload serialized as byte array.
+     * @return Instance of {@link CredentialDeploymentTransaction}.
+     */
+    public static CredentialDeploymentTransaction from(final Expiry expiry, final byte[] payloadBytes) {
+        return new CredentialDeploymentTransaction(
+                expiry,
+                Arrays.copyOf(payloadBytes, payloadBytes.length));
+    }
+
     @Override
     @UnstableApi
     byte[] getBlockItemBytes() {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Expiry.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/Expiry.java
@@ -2,6 +2,8 @@ package com.concordium.sdk.transactions;
 
 import com.concordium.sdk.types.Timestamp;
 import com.concordium.sdk.types.UInt64;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.EqualsAndHashCode;
 
 import java.util.Date;
@@ -12,10 +14,11 @@ import java.util.Date;
 @EqualsAndHashCode
 public final class Expiry {
     public static final int BYTES = UInt64.BYTES;
-    private final Timestamp timestampInMillis;
+
+    private final Timestamp expiry;
 
     private Expiry(Timestamp value) {
-        this.timestampInMillis = value;
+        this.expiry = value;
     }
 
     private static final int MILLISECONDS_PER_SECOND = 1000;
@@ -32,7 +35,7 @@ public final class Expiry {
         if (minutes < 1) {
             throw new IllegalArgumentException("Minutes must be positive.");
         }
-        return Expiry.from(Timestamp.newMillis(this.timestampInMillis.getMillis() + ((long) minutes * MILLISECONDS_PER_SECOND * SECONDS_PER_MINUTE)));
+        return Expiry.from(Timestamp.newMillis(this.expiry.getMillis() + ((long) minutes * MILLISECONDS_PER_SECOND * SECONDS_PER_MINUTE)));
     }
 
     /**
@@ -46,7 +49,7 @@ public final class Expiry {
         if (seconds < 0) {
             throw new IllegalArgumentException("Seconds must be positive.");
         }
-        return Expiry.from(Timestamp.newMillis(this.timestampInMillis.getMillis() + (long) seconds * MILLISECONDS_PER_SECOND));
+        return Expiry.from(Timestamp.newMillis(this.expiry.getMillis() + (long) seconds * MILLISECONDS_PER_SECOND));
     }
 
     /**
@@ -91,13 +94,14 @@ public final class Expiry {
         return new Expiry(timestamp);
     }
 
-    UInt64 getValue() {
-        return UInt64.from(timestampInMillis.getMillis() / 1000);
+    @JsonProperty("expiry")
+    public UInt64 getValue() {
+        return UInt64.from(expiry.getMillis() / 1000);
     }
 
     @Override
     public String toString() {
-        return timestampInMillis.toString();
+        return expiry.toString();
     }
 
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/types/Timestamp.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/types/Timestamp.java
@@ -2,6 +2,8 @@ package com.concordium.sdk.types;
 
 import com.concordium.sdk.Constants;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -16,6 +18,7 @@ import java.time.ZonedDateTime;
 public class Timestamp {
 
     @Getter
+    @JsonValue
     private final long millis;
 
     @JsonCreator

--- a/concordium-sdk/src/test/java/com/concordium/sdk/crypto/wallet/CredentialTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/crypto/wallet/CredentialTest.java
@@ -7,7 +7,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,8 +24,8 @@ import com.concordium.sdk.responses.blocksummary.updates.queues.IdentityProvider
 import com.concordium.sdk.responses.cryptographicparameters.CryptographicParameters;
 import com.concordium.sdk.serializing.JsonMapper;
 import com.concordium.sdk.transactions.CredentialPublicKeys;
+import com.concordium.sdk.transactions.Expiry;
 import com.concordium.sdk.transactions.Index;
-import com.concordium.sdk.transactions.TransactionExpiry;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
@@ -91,7 +90,7 @@ public class CredentialTest {
             .build();
 
         UnsignedCredentialDeploymentInfoWithRandomness result = Credential.createUnsignedCredential(input);
-        TransactionExpiry expiry = TransactionExpiry.fromLong(new Date().getTime() + 360);
+        Expiry expiry = Expiry.createNew().addMinutes(5);
 
         byte[] credentialDeploymentSignDigest = Credential.getCredentialDeploymentSignDigest(new CredentialDeploymentDetails(result.getUnsignedCdi(), expiry));
         ED25519SecretKey signingKey = wallet.getAccountSigningKey(0, 0, credentialCounter);


### PR DESCRIPTION
## Purpose
- Use the `Expiry` type instead of `TransactionExpiry` for credential deployment transactions to align with account transactions.

## Changes
- Fix an issue where the library for example wallet was not placed correctly.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.