### PR TITLE
Fix bug where AccountInfo could fail if there were no pendingchange for a delegator or validator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Fix a bug that caused `getAccountInfo` to fail for delegator and baker accounts if they had no stake pending changes. 
    This change is also propagated to the type level such that `Baker` and `AccountDelegation` retains an `Optional<PendingChange>` 
    as opposed to just `PendingChange`.
+ - Fix .equals() for AccountInfo such that all fields are used to deduce equality.<
 
 ## 6.1.0
 - Purge remaining usages of V1 GRPC API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Unreleased changes
+ - Fix a bug that caused `getAccountInfo` to fail for delegator and baker accounts if they had no stake pending changes. 
+   This change is also propagated to the type level such that `Baker` and `AccountDelegation` retains an `Optional<PendingChange>` 
+   as opposed to just `PendingChange`.
+
 ## 6.1.0
 - Purge remaining usages of V1 GRPC API.
 - Added support for android through an AAR artifact.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
@@ -27,7 +27,6 @@ import com.concordium.sdk.crypto.ed25519.ED25519PublicKey;
 import com.concordium.sdk.crypto.elgamal.ElgamalPublicKey;
 import com.concordium.sdk.crypto.pedersencommitment.PedersenCommitmentKey;
 import com.concordium.sdk.crypto.pointchevalsanders.PSPublicKey;
-import com.concordium.sdk.crypto.wallet.credential.CredentialDeploymentDetails;
 import com.concordium.sdk.requests.AccountQuery;
 import com.concordium.sdk.requests.BlockQuery;
 import com.concordium.sdk.requests.EpochQuery;
@@ -325,7 +324,7 @@ interface ClientV2MapperExtensions {
     @Nullable
     static AccountDelegation to(com.concordium.grpc.v2.AccountStakingInfo.Delegator stake) {
         return AccountDelegation.builder()
-                .pendingChange(to(stake.getPendingChange()))
+                .pendingChange(stake.hasPendingChange() ? Optional.of(to(stake.getPendingChange())) : Optional.empty())
                 .restakeEarnings(stake.getRestakeEarnings())
                 .stakedAmount(to(stake.getStakedAmount()))
                 .target(to(stake.getTarget()))
@@ -343,7 +342,7 @@ interface ClientV2MapperExtensions {
 
     static Baker to(com.concordium.grpc.v2.AccountStakingInfo.Baker stake) {
         return Baker.builder()
-                .pendingChange(to(stake.getPendingChange()))
+                .pendingChange(stake.hasPendingChange() ? Optional.of(to(stake.getPendingChange())) : Optional.empty())
                 .restakeEarnings(stake.getRestakeEarnings())
                 .stakedAmount(to(stake.getStakedAmount()))
                 .bakerPoolInfo(to(stake.getPoolInfo()))
@@ -369,7 +368,7 @@ interface ClientV2MapperExtensions {
                         .build();
             default:
             case CHANGE_NOT_SET:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("Expected PendingChange to be set.");
         }
     }
 
@@ -874,13 +873,13 @@ interface ClientV2MapperExtensions {
         TransactionTime time = to(credentialDeploymentTransaction.getExpiry().getValue());
 
         return SendBlockItemRequest.newBuilder()
-            .setCredentialDeployment(
-                CredentialDeployment.newBuilder()
-                    .setMessageExpiry(time)
-                    .setRawPayload(ByteString.copyFrom(credentialDeploymentTransaction.getPayloadBytes()))
-                    .build()
+                .setCredentialDeployment(
+                        CredentialDeployment.newBuilder()
+                                .setMessageExpiry(time)
+                                .setRawPayload(ByteString.copyFrom(credentialDeploymentTransaction.getPayloadBytes()))
+                                .build()
                 )
-            .build();
+                .build();
     }
 
     static AccountTransactionSignature to(TransactionSignature signature) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
@@ -324,7 +324,7 @@ interface ClientV2MapperExtensions {
     @Nullable
     static AccountDelegation to(com.concordium.grpc.v2.AccountStakingInfo.Delegator stake) {
         return AccountDelegation.builder()
-                .pendingChange(stake.hasPendingChange() ? Optional.of(to(stake.getPendingChange())) : Optional.empty())
+                .pendingChange(to(stake.getPendingChange()))
                 .restakeEarnings(stake.getRestakeEarnings())
                 .stakedAmount(to(stake.getStakedAmount()))
                 .target(to(stake.getTarget()))
@@ -342,7 +342,7 @@ interface ClientV2MapperExtensions {
 
     static Baker to(com.concordium.grpc.v2.AccountStakingInfo.Baker stake) {
         return Baker.builder()
-                .pendingChange(stake.hasPendingChange() ? Optional.of(to(stake.getPendingChange())) : Optional.empty())
+                .pendingChange(to(stake.getPendingChange()))
                 .restakeEarnings(stake.getRestakeEarnings())
                 .stakedAmount(to(stake.getStakedAmount()))
                 .bakerPoolInfo(to(stake.getPoolInfo()))
@@ -354,21 +354,21 @@ interface ClientV2MapperExtensions {
         return com.concordium.sdk.responses.BakerId.from(bakerId.getValue());
     }
 
-    static PendingChange to(StakePendingChange pendingChange) {
+    static Optional<PendingChange> to(StakePendingChange pendingChange) {
         switch (pendingChange.getChangeCase()) {
             case REDUCE:
                 StakePendingChange.Reduce reduce = pendingChange.getReduce();
-                return ReduceStakeChange.builder()
+                return Optional.of(ReduceStakeChange.builder()
                         .effectiveTime(Timestamp.from(reduce.getEffectiveTime()))
                         .newStake(to(reduce.getNewStake()))
-                        .build();
+                        .build());
             case REMOVE:
-                return RemoveStakeChange.builder()
+                return Optional.of(RemoveStakeChange.builder()
                         .effectiveTime(Timestamp.from(pendingChange.getRemove()))
-                        .build();
+                        .build());
             default:
             case CHANGE_NOT_SET:
-                throw new IllegalArgumentException("Expected PendingChange to be set.");
+                return Optional.empty();
         }
     }
 
@@ -873,13 +873,13 @@ interface ClientV2MapperExtensions {
         TransactionTime time = to(credentialDeploymentTransaction.getExpiry().getValue());
 
         return SendBlockItemRequest.newBuilder()
-                .setCredentialDeployment(
-                        CredentialDeployment.newBuilder()
-                                .setMessageExpiry(time)
-                                .setRawPayload(ByteString.copyFrom(credentialDeploymentTransaction.getPayloadBytes()))
-                                .build()
+            .setCredentialDeployment(
+                CredentialDeployment.newBuilder()
+                        .setMessageExpiry(time)
+                        .setRawPayload(ByteString.copyFrom(credentialDeploymentTransaction.getPayloadBytes()))
+                        .build()
                 )
-                .build();
+            .build();
     }
 
     static AccountTransactionSignature to(TransactionSignature signature) {
@@ -1181,9 +1181,7 @@ interface ClientV2MapperExtensions {
         return com.concordium.sdk.responses.DelegatorInfo.builder()
                 .account(to(delegatorInfo.getAccount()))
                 .stake(to(delegatorInfo.getStake()))
-                .pendingChange(delegatorInfo.hasPendingChange()
-                        ? Optional.of(to(delegatorInfo.getPendingChange()))
-                        : Optional.empty())
+                .pendingChange(to(delegatorInfo.getPendingChange()))
                 .build();
     }
 

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/accountinfo/AccountDelegation.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/accountinfo/AccountDelegation.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
+import java.util.Optional;
+
 /**
  * If the account is delegating.
  */
@@ -32,6 +34,7 @@ public final class AccountDelegation {
 
     /**
      * The pending changes for the delegator.
+     * Only present if there is a {@link PendingChange} for the delegator.
      */
-    private final PendingChange pendingChange;
+    private final Optional<PendingChange> pendingChange;
 }

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/accountinfo/AccountInfo.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/accountinfo/AccountInfo.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 /**
  * Information of an account on chain.
  */
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Data
 @Jacksonized
 @Builder
@@ -27,7 +26,6 @@ public final class AccountInfo {
     /**
      * The account address.
      */
-    @EqualsAndHashCode.Include
     private final AccountAddress accountAddress;
     /**
      * The current nonce for the account.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/accountinfo/Baker.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/accountinfo/Baker.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.jackson.Jacksonized;
 
+import java.util.Optional;
+
 @ToString
 @EqualsAndHashCode
 @Jacksonized
@@ -43,9 +45,10 @@ public final class Baker {
 
     /**
      * The pending changes for the baker.
+     * Only present if there is a pending change for the baker.
      */
     @Getter
-    private final PendingChange pendingChange;
+    private final Optional<PendingChange> pendingChange;
 
     /**
      * The baker pool info

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
@@ -390,9 +390,9 @@ public class ClientV2GetAccountInfoTest {
 
     @Test
     public void mapPendingRemoveStakeChangeTest() {
-        var expected = RemoveStakeChange.builder()
+        var expected = Optional.of(RemoveStakeChange.builder()
                 .effectiveTime(com.concordium.sdk.types.Timestamp.newMillis(BAKER_REDUCE_STAKE_TIME))
-                .build();
+                .build());
 
         var res = ClientV2MapperExtensions.to(StakePendingChange.newBuilder()
                 .setRemove(Timestamp.newBuilder().setValue(BAKER_REDUCE_STAKE_TIME).build())

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
@@ -53,6 +54,8 @@ public class ClientV2GetAccountInfoTest {
 
     private static final com.concordium.sdk.types.AccountAddress ACCOUNT_ADDRESS_1
             = com.concordium.sdk.types.AccountAddress.from("37UHs4b9VH3F366cdmrA4poBURzzARJLWxdXZ18zoa9pnfhhDf");
+    private static final com.concordium.sdk.types.AccountAddress ACCOUNT_ADDRESS_2
+            = com.concordium.sdk.types.AccountAddress.from("3XSLuJcXg6xEua6iBPnWacc3iWh93yEDMCqX8FbE3RDSbEnT9P");
     private static final byte[] ENCRYPTED_AMOUNT = new byte[]{0, 0, 1};
     private static final long ACCOUNT_AMOUNT = 10000;
     private static final long ACCOUNT_INDEX = 1;
@@ -113,176 +116,193 @@ public class ClientV2GetAccountInfoTest {
                     .setEffectiveTime(Timestamp.newBuilder().setValue(BAKER_REDUCE_STAKE_TIME).build())
                     .build())
             .build();
-    private static final AccountInfo GRPC_RES_1 = AccountInfo.newBuilder()
-            .setAddress(com.concordium.grpc.v2.AccountAddress.newBuilder().setValue(ByteString.copyFrom(ACCOUNT_ADDRESS_1.getBytes())).build())
-            .setAmount(Amount.newBuilder().setValue(ACCOUNT_AMOUNT).build())
-            .setEncryptedBalance(EncryptedBalance.newBuilder()
-                    .setStartIndex(ENCRYPTED_AMOUNT_START_INDEX)
-                    .setAggregatedAmount(from(ENCRYPTED_AMOUNT))
-                    .setNumAggregated(1)
-                    .addIncomingAmounts(from(ENCRYPTED_AMOUNT_INCOMING_AMOUNT_1))
-                    .setSelfAmount(from(ENCRYPTED_AMOUNT_SELF_AMOUNT_1))
-                    .build())
-            .setIndex(AccountIndex.newBuilder().setValue(ACCOUNT_INDEX).build())
-            .setThreshold(AccountThreshold.newBuilder()
-                    .setValue(ACCOUNT_THRESHOLD)
-                    .build())
-            .setEncryptionKey(EncryptionKey.newBuilder()
-                    .setValue(ByteString.copyFrom(ENCRYPTION_KEY))
-                    .build())
-            .setSchedule(ReleaseSchedule.newBuilder()
-                    .addSchedules(Release.newBuilder()
-                            .setAmount(Amount.newBuilder().setValue(RELEASE_AMOUNT).build())
-                            .setTimestamp(Timestamp.newBuilder().setValue(RELEASE_TIME).build())
-                            .addTransactions(TransactionHash.newBuilder()
-                                    .setValue(ByteString.copyFrom(RELEASE_TRANSACTION_HASH))
-                                    .build())
-                            .build())
-                    .setTotal(Amount.newBuilder().setValue(RELEASE_AMOUNT_TOTAL).build())
-                    .build())
-            .setSequenceNumber(SequenceNumber.newBuilder()
-                    .setValue(SEQUENCE_NUMBER)
-                    .build())
-            .putAllCreds(ImmutableMap.of(0, AccountCredential.newBuilder()
-                    .setNormal(NormalCredentialValues.newBuilder()
-                            .setArThreshold(ArThreshold.newBuilder().setValue(AR_THRESHOLD).build())
-                            .putAllArData(ImmutableMap.of(0, ChainArData.newBuilder()
-                                    .setEncIdCredPubShare(ByteString.copyFrom(ENC_ID_PUB_SHARE))
-                                    .build()))
-                            .setCommitments(CredentialCommitments.newBuilder()
-                                    .setCredCounter(toCommitment(COMMITMENT_CRED_COUNTER))
-                                    .setMaxAccounts(toCommitment(COMMITMENT_MAX_ACCOUNTS))
-                                    .setPrf(toCommitment(COMMITMENT_PRF))
-                                    .addIdCredSecSharingCoeff(0, toCommitment(COMMITMENT_ID_CRED_SHARING_COEFF))
-                                    .putAllAttributes(ImmutableMap.of(0, toCommitment(COMMITMENT_ATTRIBUTE_0)))
-                                    .build())
-                            .setCredId(CredentialRegistrationId.newBuilder()
-                                    .setValue(ByteString.copyFrom(CREDENTIAL_REG_ID))
-                                    .build())
-                            .setIpId(IdentityProviderIdentity.newBuilder()
-                                    .setValue(IDP_ID)
-                                    .build())
-                            .setKeys(CredentialPublicKeys.newBuilder()
-                                    .setThreshold(SignatureThreshold.newBuilder().setValue(SIGNATURE_THRESHOLD).build())
-                                    .putAllKeys(ImmutableMap.of(0, AccountVerifyKey.newBuilder()
-                                            .setEd25519Key(ByteString.copyFrom(NORMAL_CRED_SIG_0))
-                                            .build()))
-                                    .build())
-                            .setPolicy(Policy.newBuilder()
-                                    .setCreatedAt(POLICY_CREATED_AT)
-                                    .setValidTo(POLICY_VALID_TO)
-                                    .putAllAttributes(ImmutableMap.of(
-                                            FIRST_NAME.ordinal(),
-                                            ByteString.copyFrom(FIRST_NAME_VALUE)))
-                                    .build())
-                            .build())
-                    .build()))
-            .setStake(AccountStakingInfo.newBuilder()
-                    .setBaker(AccountStakingInfo.Baker.newBuilder()
-                            .setStakedAmount(Amount.newBuilder().setValue(STAKED_AMOUNT).build())
-                            .setRestakeEarnings(RESTAKE_EARNINGS)
-                            .setPendingChange(PENDING_CHANGE_GRPC)
-                            .setBakerInfo(BakerInfo.newBuilder()
-                                    .setBakerId(BakerId.newBuilder().setValue(BAKER_ID).build())
-                                    .setAggregationKey(BakerAggregationVerifyKey.newBuilder()
-                                            .setValue(ByteString.copyFrom(BAKER_AGGREGATION_KEY))
-                                            .build())
-                                    .setElectionKey(BakerElectionVerifyKey.newBuilder()
-                                            .setValue(ByteString.copyFrom(BAKER_ELECTION_VERIFY_KEY))
-                                            .build())
-                                    .setSignatureKey(BakerSignatureVerifyKey.newBuilder()
-                                            .setValue(ByteString.copyFrom(BAKER_SIGNATURE_VERIFY_KEY))
-                                            .build())
-                                    .build())
-                            .setPoolInfo(BakerPoolInfo.newBuilder()
-                                    .setUrl(BAKER_POOL_URL)
-                                    .setOpenStatus(OpenStatus.OPEN_STATUS_OPEN_FOR_ALL)
-                                    .setCommissionRates(CommissionRates.newBuilder()
-                                            .setBaking(toAmountFrac(COMMISSION_BAKING_PPHT))
-                                            .setFinalization(toAmountFrac(COMMISSION_FINALIZATION_PPHT))
-                                            .setTransaction(toAmountFrac(COMMISSION_TRANSACTION_PPHT))
-                                            .build())
-                                    .build())
-                            .build())
-                    .build())
-            .build();
 
-    private static final PendingChange PENDING_CHANGE = ReduceStakeChange.builder()
+    private static final AccountInfo GRPC_RES_1 = NEW_GRPC_RES(ACCOUNT_ADDRESS_1, PENDING_CHANGE_GRPC);
+    private static final AccountInfo GRPC_RES_3 = NEW_GRPC_RES(ACCOUNT_ADDRESS_2, PENDING_CHANGE_GRPC);
+
+    private static AccountInfo NEW_GRPC_RES(com.concordium.sdk.types.AccountAddress address, StakePendingChange pendingChange) {
+        return AccountInfo.newBuilder()
+                .setAddress(com.concordium.grpc.v2.AccountAddress.newBuilder().setValue(ByteString.copyFrom(address.getBytes())).build())
+                .setAmount(Amount.newBuilder().setValue(ACCOUNT_AMOUNT).build())
+                .setEncryptedBalance(EncryptedBalance.newBuilder()
+                        .setStartIndex(ENCRYPTED_AMOUNT_START_INDEX)
+                        .setAggregatedAmount(from(ENCRYPTED_AMOUNT))
+                        .setNumAggregated(1)
+                        .addIncomingAmounts(from(ENCRYPTED_AMOUNT_INCOMING_AMOUNT_1))
+                        .setSelfAmount(from(ENCRYPTED_AMOUNT_SELF_AMOUNT_1))
+                        .build())
+                .setIndex(AccountIndex.newBuilder().setValue(ACCOUNT_INDEX).build())
+                .setThreshold(AccountThreshold.newBuilder()
+                        .setValue(ACCOUNT_THRESHOLD)
+                        .build())
+                .setEncryptionKey(EncryptionKey.newBuilder()
+                        .setValue(ByteString.copyFrom(ENCRYPTION_KEY))
+                        .build())
+                .setSchedule(ReleaseSchedule.newBuilder()
+                        .addSchedules(Release.newBuilder()
+                                .setAmount(Amount.newBuilder().setValue(RELEASE_AMOUNT).build())
+                                .setTimestamp(Timestamp.newBuilder().setValue(RELEASE_TIME).build())
+                                .addTransactions(TransactionHash.newBuilder()
+                                        .setValue(ByteString.copyFrom(RELEASE_TRANSACTION_HASH))
+                                        .build())
+                                .build())
+                        .setTotal(Amount.newBuilder().setValue(RELEASE_AMOUNT_TOTAL).build())
+                        .build())
+                .setSequenceNumber(SequenceNumber.newBuilder()
+                        .setValue(SEQUENCE_NUMBER)
+                        .build())
+                .putAllCreds(ImmutableMap.of(0, AccountCredential.newBuilder()
+                        .setNormal(NormalCredentialValues.newBuilder()
+                                .setArThreshold(ArThreshold.newBuilder().setValue(AR_THRESHOLD).build())
+                                .putAllArData(ImmutableMap.of(0, ChainArData.newBuilder()
+                                        .setEncIdCredPubShare(ByteString.copyFrom(ENC_ID_PUB_SHARE))
+                                        .build()))
+                                .setCommitments(CredentialCommitments.newBuilder()
+                                        .setCredCounter(toCommitment(COMMITMENT_CRED_COUNTER))
+                                        .setMaxAccounts(toCommitment(COMMITMENT_MAX_ACCOUNTS))
+                                        .setPrf(toCommitment(COMMITMENT_PRF))
+                                        .addIdCredSecSharingCoeff(0, toCommitment(COMMITMENT_ID_CRED_SHARING_COEFF))
+                                        .putAllAttributes(ImmutableMap.of(0, toCommitment(COMMITMENT_ATTRIBUTE_0)))
+                                        .build())
+                                .setCredId(CredentialRegistrationId.newBuilder()
+                                        .setValue(ByteString.copyFrom(CREDENTIAL_REG_ID))
+                                        .build())
+                                .setIpId(IdentityProviderIdentity.newBuilder()
+                                        .setValue(IDP_ID)
+                                        .build())
+                                .setKeys(CredentialPublicKeys.newBuilder()
+                                        .setThreshold(SignatureThreshold.newBuilder().setValue(SIGNATURE_THRESHOLD).build())
+                                        .putAllKeys(ImmutableMap.of(0, AccountVerifyKey.newBuilder()
+                                                .setEd25519Key(ByteString.copyFrom(NORMAL_CRED_SIG_0))
+                                                .build()))
+                                        .build())
+                                .setPolicy(Policy.newBuilder()
+                                        .setCreatedAt(POLICY_CREATED_AT)
+                                        .setValidTo(POLICY_VALID_TO)
+                                        .putAllAttributes(ImmutableMap.of(
+                                                FIRST_NAME.ordinal(),
+                                                ByteString.copyFrom(FIRST_NAME_VALUE)))
+                                        .build())
+                                .build())
+                        .build()))
+                .setStake(AccountStakingInfo.newBuilder()
+                        .setBaker(AccountStakingInfo.Baker.newBuilder()
+                                .setStakedAmount(Amount.newBuilder().setValue(STAKED_AMOUNT).build())
+                                .setRestakeEarnings(RESTAKE_EARNINGS)
+                                .setPendingChange(pendingChange)
+                                .setBakerInfo(BakerInfo.newBuilder()
+                                        .setBakerId(BakerId.newBuilder().setValue(BAKER_ID).build())
+                                        .setAggregationKey(BakerAggregationVerifyKey.newBuilder()
+                                                .setValue(ByteString.copyFrom(BAKER_AGGREGATION_KEY))
+                                                .build())
+                                        .setElectionKey(BakerElectionVerifyKey.newBuilder()
+                                                .setValue(ByteString.copyFrom(BAKER_ELECTION_VERIFY_KEY))
+                                                .build())
+                                        .setSignatureKey(BakerSignatureVerifyKey.newBuilder()
+                                                .setValue(ByteString.copyFrom(BAKER_SIGNATURE_VERIFY_KEY))
+                                                .build())
+                                        .build())
+                                .setPoolInfo(BakerPoolInfo.newBuilder()
+                                        .setUrl(BAKER_POOL_URL)
+                                        .setOpenStatus(OpenStatus.OPEN_STATUS_OPEN_FOR_ALL)
+                                        .setCommissionRates(CommissionRates.newBuilder()
+                                                .setBaking(toAmountFrac(COMMISSION_BAKING_PPHT))
+                                                .setFinalization(toAmountFrac(COMMISSION_FINALIZATION_PPHT))
+                                                .setTransaction(toAmountFrac(COMMISSION_TRANSACTION_PPHT))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static final Optional<PendingChange> PENDING_CHANGE = Optional.of(ReduceStakeChange.builder()
             .newStake(CCDAmount.fromMicro(BAKER_REDUCE_STAKE_AMOUNT))
             .effectiveTime(com.concordium.sdk.types.Timestamp.newMillis(BAKER_REDUCE_STAKE_TIME))
-            .build();
-    private static final com.concordium.sdk.responses.accountinfo.AccountInfo ACCOUNT_INFO_RES_EXPECTED_1
-            = com.concordium.sdk.responses.accountinfo.AccountInfo.builder()
-            .accountAddress(ACCOUNT_ADDRESS_1)
-            .accountAmount(CCDAmount.fromMicro(ACCOUNT_AMOUNT))
-            .accountEncryptedAmount(AccountEncryptedAmount.builder()
-                    .startIndex(EncryptedAmountIndex.from(ENCRYPTED_AMOUNT_START_INDEX))
-                    .selfAmount(com.concordium.sdk.transactions.EncryptedAmount.from(ENCRYPTED_AMOUNT_SELF_AMOUNT_1))
-                    .incomingAmounts(ImmutableList.of(com.concordium.sdk.transactions.EncryptedAmount.from(ENCRYPTED_AMOUNT_INCOMING_AMOUNT_1)))
-                    .numAggregated(Optional.of(1))
-                    .aggregatedAmount(Optional.of(com.concordium.sdk.transactions.EncryptedAmount.from(ENCRYPTED_AMOUNT)))
-                    .build())
-            .accountIndex(com.concordium.sdk.responses.AccountIndex.from(ACCOUNT_INDEX))
-            .accountThreshold(ACCOUNT_THRESHOLD)
-            .accountEncryptionKey(ElgamalPublicKey.from(ENCRYPTION_KEY))
-            .accountReleaseSchedule(com.concordium.sdk.responses.accountinfo.ReleaseSchedule.builder()
-                    .total(CCDAmount.fromMicro(RELEASE_AMOUNT_TOTAL))
-                    .schedule(ImmutableList.of(ScheduledRelease.builder()
-                            .amount(CCDAmount.fromMicro(RELEASE_AMOUNT))
-                            .timestamp(com.concordium.sdk.types.Timestamp.newMillis(RELEASE_TIME))
-                            .transaction(Hash.from(RELEASE_TRANSACTION_HASH))
-                            .build()))
-                    .build())
-            .accountNonce(Nonce.from(SEQUENCE_NUMBER))
-            .accountCredential(Index.from(0), Credential
-                    .builder()
-                    .type(CredentialType.NORMAL)
-                    .revocationThreshold(AR_THRESHOLD)
-                    .arDataItem(Index.from(0), ArData.builder()
-                            .encIdCredPubShare(EncIdPubShare.from(ENC_ID_PUB_SHARE))
-                            .build())
-                    .commitments(Commitments.builder()
-                            .cmmCredCounter(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_CRED_COUNTER))
-                            .cmmIdCredSecSharingCoeffItem(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_ID_CRED_SHARING_COEFF))
-                            .cmmMaxAccounts(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_MAX_ACCOUNTS))
-                            .cmmPrf(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_PRF))
-                            .cmmAttribute(FIRST_NAME, com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_ATTRIBUTE_0))
-                            .build())
-                    .credId(fromBytes(CREDENTIAL_REG_ID))
-                    .ipIdentity(IDP_ID)
-                    .credentialPublicKeys(com.concordium.sdk.responses.accountinfo.credential.CredentialPublicKeys.builder()
-                            .threshold(SIGNATURE_THRESHOLD)
-                            .key(Index.from(0), Key.builder()
-                                    .verifyKey(NORMAL_CRED_SIG_0)
-                                    .schemeId(VerificationScheme.Ed25519).build())
-                            .build())
-                    .policy(com.concordium.sdk.responses.accountinfo.credential.Policy.builder()
-                            .createdAt(of(POLICY_CREATED_AT.getYear(), POLICY_CREATED_AT.getMonth()))
-                            .validTo(of(POLICY_VALID_TO.getYear(), POLICY_VALID_TO.getMonth()))
-                            .revealedAttributes(ImmutableMap.of(FIRST_NAME, new String(FIRST_NAME_VALUE, StandardCharsets.UTF_8)))
-                            .build())
-                    .build())
-            .bakerInfo(Baker
-                    .builder()
-                    .stakedAmount(CCDAmount.fromMicro(STAKED_AMOUNT))
-                    .restakeEarnings(RESTAKE_EARNINGS)
-                    .pendingChange(PENDING_CHANGE)
-                    .bakerInfo(com.concordium.sdk.responses.bakersrewardperiod.BakerInfo.builder()
-                            .bakerId(com.concordium.sdk.responses.BakerId.from(BAKER_ID))
-                            .bakerAggregationVerifyKey(BLSPublicKey.from(BAKER_AGGREGATION_KEY))
-                            .bakerElectionVerifyKey(VRFPublicKey.from(BAKER_ELECTION_VERIFY_KEY))
-                            .bakerSignatureVerifyKey(ED25519PublicKey.from(BAKER_SIGNATURE_VERIFY_KEY)).build())
-                    .bakerPoolInfo(com.concordium.sdk.responses.accountinfo.BakerPoolInfo.builder()
-                            .metadataUrl(BAKER_POOL_URL)
-                            .openStatus(com.concordium.sdk.responses.transactionstatus.OpenStatus.OPEN_FOR_ALL)
-                            .commissionRates(com.concordium.sdk.responses.accountinfo.CommissionRates.builder()
-                                    .bakingCommission((double) COMMISSION_BAKING_PPHT / 100_000D)
-                                    .finalizationCommission((double) COMMISSION_FINALIZATION_PPHT / 100_000D)
-                                    .transactionCommission((double) COMMISSION_TRANSACTION_PPHT / 100_000D)
-                                    .build())
-                            .build())
-                    .build())
-            .build();
+            .build());
+
+    private static final com.concordium.sdk.responses.accountinfo.AccountInfo ACCOUNT_INFO_RES_EXPECTED_1 = NEW_EXPECTED_GRPC_RES(ACCOUNT_ADDRESS_1, PENDING_CHANGE);
+
+    private static final com.concordium.sdk.responses.accountinfo.AccountInfo ACCOUNT_INFO_RES_EXPECTED_2 = NEW_EXPECTED_GRPC_RES(ACCOUNT_ADDRESS_2, Optional.empty());
+
+    private static com.concordium.sdk.responses.accountinfo.AccountInfo NEW_EXPECTED_GRPC_RES(com.concordium.sdk.types.AccountAddress address, Optional<PendingChange> pendingChange) {
+        return com.concordium.sdk.responses.accountinfo.AccountInfo.builder().
+                accountAddress(address).
+                accountAmount(CCDAmount.fromMicro(ACCOUNT_AMOUNT)).
+                accountEncryptedAmount(AccountEncryptedAmount.builder().
+                        startIndex(EncryptedAmountIndex.from(ENCRYPTED_AMOUNT_START_INDEX)).
+                        selfAmount(com.concordium.sdk.transactions.EncryptedAmount.from(ENCRYPTED_AMOUNT_SELF_AMOUNT_1)).
+                        incomingAmounts(ImmutableList.of(com.concordium.sdk.transactions.EncryptedAmount.from(ENCRYPTED_AMOUNT_INCOMING_AMOUNT_1))).
+                        numAggregated(Optional.of(1)).
+                        aggregatedAmount(Optional.of(com.concordium.sdk.transactions.EncryptedAmount.from(ENCRYPTED_AMOUNT))).
+                        build()).
+                accountIndex(com.concordium.sdk.responses.AccountIndex.from(ACCOUNT_INDEX)).
+                accountThreshold(ACCOUNT_THRESHOLD).
+                accountEncryptionKey(ElgamalPublicKey.from(ENCRYPTION_KEY)).
+                accountReleaseSchedule(com.concordium.sdk.responses.accountinfo.ReleaseSchedule.builder().
+                        total(CCDAmount.fromMicro(RELEASE_AMOUNT_TOTAL)).
+                        schedule(ImmutableList.of(ScheduledRelease.builder().
+                                amount(CCDAmount.fromMicro(RELEASE_AMOUNT)).
+                                timestamp(com.concordium.sdk.types.Timestamp.newMillis(RELEASE_TIME)).
+                                transaction(Hash.from(RELEASE_TRANSACTION_HASH)).
+                                build())).
+                        build()).
+                accountNonce(Nonce.from(SEQUENCE_NUMBER)).
+                accountCredential(Index.from(0), Credential.
+                        builder().
+                        type(CredentialType.NORMAL).
+                        revocationThreshold(AR_THRESHOLD).
+                        arDataItem(Index.from(0), ArData.
+                                builder().
+                                encIdCredPubShare(EncIdPubShare.from(ENC_ID_PUB_SHARE)).
+                                build()).
+                        commitments(Commitments.builder().
+                                cmmCredCounter(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_CRED_COUNTER)).
+                                cmmIdCredSecSharingCoeffItem(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_ID_CRED_SHARING_COEFF)).
+                                cmmMaxAccounts(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_MAX_ACCOUNTS)).
+                                cmmPrf(com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_PRF)).
+                                cmmAttribute(FIRST_NAME, com.concordium.sdk.responses.accountinfo.credential.Commitment.from(COMMITMENT_ATTRIBUTE_0)).
+                                build()).
+                        credId(fromBytes(CREDENTIAL_REG_ID)).
+                        ipIdentity(IDP_ID).
+                        credentialPublicKeys(com.concordium.sdk.responses.accountinfo.credential.CredentialPublicKeys.builder().
+                                threshold(SIGNATURE_THRESHOLD).
+                                key(Index.from(0), Key.
+                                        builder().
+                                        verifyKey(NORMAL_CRED_SIG_0).
+                                        schemeId(VerificationScheme.Ed25519).
+                                        build()).
+                                build()).
+                        policy(com.concordium.sdk.responses.accountinfo.credential.Policy.builder().
+                                createdAt(of(POLICY_CREATED_AT.getYear(), POLICY_CREATED_AT.
+                                        getMonth())).
+                                validTo(of(POLICY_VALID_TO.getYear(), POLICY_VALID_TO.
+                                        getMonth())).
+                                revealedAttributes(ImmutableMap.of(FIRST_NAME, new String(FIRST_NAME_VALUE, StandardCharsets.UTF_8))).
+                                build()).build()).
+                bakerInfo(Baker.builder().
+                        stakedAmount(CCDAmount.fromMicro(STAKED_AMOUNT)).
+                        restakeEarnings(RESTAKE_EARNINGS).
+                        pendingChange(pendingChange).
+                        bakerInfo(com.concordium.sdk.responses.bakersrewardperiod.BakerInfo.builder().
+                                bakerId(com.concordium.sdk.responses.BakerId.from(BAKER_ID)).
+                                bakerAggregationVerifyKey(BLSPublicKey.from(BAKER_AGGREGATION_KEY)).
+                                bakerElectionVerifyKey(VRFPublicKey.from(BAKER_ELECTION_VERIFY_KEY)).
+                                bakerSignatureVerifyKey(ED25519PublicKey.from(BAKER_SIGNATURE_VERIFY_KEY)).
+                                build()).
+                        bakerPoolInfo(com.concordium.sdk.responses.accountinfo.BakerPoolInfo.builder().
+                                metadataUrl(BAKER_POOL_URL).
+                                openStatus(com.concordium.sdk.responses.transactionstatus.OpenStatus.OPEN_FOR_ALL).
+                                commissionRates(com.concordium.sdk.responses.accountinfo.CommissionRates.builder().
+                                        bakingCommission((double) COMMISSION_BAKING_PPHT / 100_000D).
+                                        finalizationCommission((double) COMMISSION_FINALIZATION_PPHT / 100_000D).
+                                        transactionCommission((double) COMMISSION_TRANSACTION_PPHT / 100_000D).
+                                        build()).
+                                build()).
+                        build()).
+                build();
+
+    }
 
     private static AmountFraction toAmountFrac(int commissionPartsPerHundredThousand) {
         return AmountFraction.newBuilder().setPartsPerHundredThousand(commissionPartsPerHundredThousand).build();
@@ -304,6 +324,9 @@ public class ClientV2GetAccountInfoTest {
                         responseObserver.onNext(GRPC_RES_1);
                     if (request.getAccountIdentifier().getAddress().equals(GRPC_RES_2.getAddress()))
                         responseObserver.onNext(GRPC_RES_2);
+                    if (request.getAccountIdentifier().getAddress().equals(GRPC_RES_3.getAddress()))
+                        responseObserver.onNext(GRPC_RES_3);
+
                     responseObserver.onCompleted();
                 }
             }
@@ -321,6 +344,7 @@ public class ClientV2GetAccountInfoTest {
         ManagedChannel channel = grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build());
         client = new ClientV2(10000, channel, Optional.empty());
+        Mockito.reset(serviceImpl);
     }
 
     @Test
@@ -329,6 +353,14 @@ public class ClientV2GetAccountInfoTest {
 
         verify(serviceImpl).getAccountInfo(any(AccountInfoRequest.class), any(StreamObserver.class));
         assertEquals(ACCOUNT_INFO_RES_EXPECTED_1, res);
+    }
+
+    @Test
+    public void getAccountInfoNoPendingChangeTest() {
+        var res = client.getAccountInfo(BlockQuery.BEST, AccountQuery.from(ACCOUNT_ADDRESS_2));
+
+        verify(serviceImpl).getAccountInfo(any(AccountInfoRequest.class), any(StreamObserver.class));
+        assertEquals(ACCOUNT_INFO_RES_EXPECTED_2, res);
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Fix https://github.com/Concordium/concordium-java-sdk/issues/306

## Changes

- Fixed  parsing of the delegator / baker stake objects
- `Baker` and `AccountDelegation` now exposes `Optional<PendingChange>` as opposed to just
  `PendingChange`.
- Fix `.equals` on `AccountInfo`
- Added a test

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
