### PR TITLE
Fix bug in AccountIndex serialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # Unreleased changes
+ - Fix a bug in the serialization of `AccountIndex`
  - Fix a bug that caused `getAccountInfo` to fail for delegator and baker accounts if they had no stake pending changes. 
    This change is also propagated to the type level such that `Baker` and `AccountDelegation` retains an `Optional<PendingChange>` 
    as opposed to just `PendingChange`.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/responses/AccountIndex.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/responses/AccountIndex.java
@@ -38,9 +38,7 @@ public final class AccountIndex implements ID{
     }
 
     public byte[] getBytes() {
-        val buffer = ByteBuffer.allocate(UInt16.BYTES);
-        buffer.put(index.getBytes());
-        return buffer.array();
+        return this.index.getBytes();
     }
 
     @Override


### PR DESCRIPTION
## Purpose

Address https://github.com/Concordium/concordium-java-sdk/issues/308

## Changes

Properly serialize the `AccountIndex` as 8 bytes as opposed to two bytes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

