### PR TITLE
Fix wallet sdk bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 - Added `Web3IdProof` class with `getWeb3IdProof` method to create Presentations. (And supporting classes)
+- Fixed an issue where `ConcordiumHdWallet.fromSeedPhrase` always produced an invalid seed as hex.
 
 ## 7.0.0
 - Make the `energy` parameter for invoking an instance `Optional`.

--- a/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/Storage.kt
+++ b/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/Storage.kt
@@ -21,7 +21,6 @@ class Storage(context: Context) {
     val accountAddress = StorageAccessor(sharedPreferences, "account_address")
     val identity = StorageAccessor(sharedPreferences, "identity")
 
-    @OptIn(ExperimentalStdlibApi::class)
     fun getWallet(): ConcordiumHdWallet {
         val seedPhrase = this.seedPhrase.get()
         return ConcordiumHdWallet.fromSeedPhrase(seedPhrase, Constants.NETWORK)

--- a/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/Storage.kt
+++ b/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/Storage.kt
@@ -3,8 +3,6 @@ package com.concordium.example.wallet
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.activity.ComponentActivity
-import cash.z.ecc.android.bip39.Mnemonics
-import cash.z.ecc.android.bip39.toSeed
 import com.concordium.sdk.crypto.wallet.ConcordiumHdWallet
 
 /***
@@ -26,8 +24,7 @@ class Storage(context: Context) {
     @OptIn(ExperimentalStdlibApi::class)
     fun getWallet(): ConcordiumHdWallet {
         val seedPhrase = this.seedPhrase.get()
-        val seedAsHex = Mnemonics.MnemonicCode(seedPhrase!!.toCharArray()).toSeed().toHexString()
-        return ConcordiumHdWallet.fromHex(seedAsHex, Constants.NETWORK)
+        return ConcordiumHdWallet.fromSeedPhrase(seedPhrase, Constants.NETWORK)
     }
 }
 

--- a/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/activities/AccountActivity.kt
+++ b/concordium-android-wallet-example/app/src/main/java/com/concordium/example/wallet/activities/AccountActivity.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.sp
 import com.concordium.sdk.crypto.ed25519.ED25519SecretKey
 import com.concordium.sdk.requests.AccountQuery
 import com.concordium.sdk.requests.BlockQuery
-import com.concordium.sdk.transactions.AccountNonce
 import com.concordium.sdk.transactions.CCDAmount
 import com.concordium.sdk.transactions.Expiry
 import com.concordium.sdk.transactions.Index
@@ -70,13 +69,13 @@ class AccountActivity : ComponentActivity() {
 
         val client = ConcordiumClientService.getClient()
         val senderInfo = client.getAccountInfo(BlockQuery.BEST, AccountQuery.from(sender))
-        val nonce = senderInfo.accountNonce
+        val nonce = senderInfo.nonce
         val transactionHash = client.sendTransaction(
             TransactionFactory.newTransfer()
                 .sender(sender)
                 .receiver(receiver)
                 .amount(amount)
-                .nonce(AccountNonce.from(nonce))
+                .nonce(nonce)
                 .expiry(expiry)
                 .signer(signer)
                 .build()

--- a/concordium-sdk/src/main/java/com/concordium/sdk/crypto/wallet/ConcordiumHdWallet.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/crypto/wallet/ConcordiumHdWallet.java
@@ -82,7 +82,7 @@ public class ConcordiumHdWallet {
         byte[] seed = MnemonicCode.toSeed(seedPhrase, "");
         StringBuilder sb = new StringBuilder();
         for (byte b : seed) {
-            sb.append(String.format("%02X ", b));
+            sb.append(String.format("%02X", b));
         }
         return new ConcordiumHdWallet(sb.toString(), network);
     }

--- a/concordium-sdk/src/test/java/com/concordium/sdk/crypto/wallet/ConcordiumHdWalletTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/crypto/wallet/ConcordiumHdWalletTest.java
@@ -60,6 +60,17 @@ public class ConcordiumHdWalletTest {
         ConcordiumHdWallet.fromSeedPhrase(validSeedPhrase, Network.MAINNET);
     }
 
+    @Test
+    public void testWalletFromSeedAndFromPhraseProduceEqualIdCredSec() throws IOException, MnemonicException {
+        Network network = Network.MAINNET;
+        String validSeedPhrase = "plug pipe now victory right then canvas monkey treat weasel bacon skull that shaft rookie sell adjust chase trumpet depth asthma traffic code castle";
+
+        ConcordiumHdWallet walletFromPhrase = ConcordiumHdWallet.fromSeedPhrase(validSeedPhrase, network);
+        ConcordiumHdWallet walletFromSeed = ConcordiumHdWallet.fromHex("5f9649eb1aeb049e095324f5a012188f3a0eebb56ed622b683686b0d603f114b421a86bbfa2d60ac64c3841d0a0b944abc510b50546645083a7ac9acbee27d25", network); 
+
+        assertEquals(walletFromPhrase.getIdCredSec(0, 0), walletFromSeed.getIdCredSec(0, 0));
+    }
+
     private static String TEST_SEED = "efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860";
 
     @Test


### PR DESCRIPTION
## Purpose
Fix nonce issue in example wallet (breaking change from the SDK) and fix a bug in `ConcordiumHdWallet.fromSeedPhrase` where the generated seed was invalid (contained spaces).

## Changes
- Use other nonce type.
- Remove spaces in seed as hex.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.