### PR TITLE
Removed `tag` field from CustomEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Fixed a bug in `CustomEvent`. Removed unnecessary `tag` field.
 - Added `Web3IdProof` class with `getWeb3IdProof` method to create Presentations. (And supporting classes)
 - Fixed an issue where `ConcordiumHdWallet.fromSeedPhrase` always produced an invalid seed as hex.
 

--- a/concordium-sdk/src/main/java/com/concordium/sdk/cis2/SerializationUtils.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/cis2/SerializationUtils.java
@@ -202,13 +202,13 @@ public class SerializationUtils {
             case TOKEN_METADATA:
                 return SerializationUtils.deserializeTokenMetadataEvent(buffer);
             case CUSTOM:
-                return SerializationUtils.deserializeCustomEvent(tag, buffer);
+                return SerializationUtils.deserializeCustomEvent(buffer);
         }
         throw new IllegalArgumentException("Malformed CIS2 event");
     }
 
-    private static Cis2Event deserializeCustomEvent(byte tag, ByteBuffer buffer) {
-        return new CustomEvent(tag, buffer.array());
+    private static Cis2Event deserializeCustomEvent(ByteBuffer buffer) {
+        return new CustomEvent(buffer.array());
     }
 
     @SneakyThrows

--- a/concordium-sdk/src/main/java/com/concordium/sdk/cis2/events/CustomEvent.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/cis2/events/CustomEvent.java
@@ -12,11 +12,9 @@ import lombok.ToString;
 @Getter
 public class CustomEvent implements Cis2Event {
 
-    private final byte tag;
     private final byte[] data;
 
-    public CustomEvent(byte tag, byte[] data) {
-        this.tag = tag;
+    public CustomEvent(byte[] data) {
         this.data = data;
     }
 


### PR DESCRIPTION
## Purpose

Fix #324 

## Changes

Removed the unnecesary `tag` field in `CustomEvent`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.