### PR TITLE
JAV-324 Deprecate encrypted transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Added `MessageSigningDigest` class to generate digests for message signing
 - Added support for company identity attributes
+- Deprecated encrypted transfers. They are partially removed since protocol version 7
 
 ## 7.1.0
 - Removed unnecessary  `amount` parameter from `InvokeInstanceRequest`.

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/EncryptedTransferTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/EncryptedTransferTransaction.java
@@ -6,6 +6,10 @@ import com.concordium.sdk.types.AccountAddress;
 import com.concordium.sdk.types.Nonce;
 import lombok.*;
 
+/**
+ * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
+ */
+@Deprecated
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -34,7 +38,9 @@ public class EncryptedTransferTransaction extends AccountTransaction {
      * @return Initialized {@link EncryptedTransferTransaction}.
      * @throws TransactionCreationException On failure to create the Transaction from input params.
      *                                      Ex when any of the input param is NULL.
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
+    @Deprecated
     @Builder
     public static EncryptedTransferTransaction from(final EncryptedAmountTransferData data,
                                                     final AccountAddress receiver,

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/EncryptedTransferWithMemoTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/EncryptedTransferWithMemoTransaction.java
@@ -6,6 +6,10 @@ import com.concordium.sdk.types.AccountAddress;
 import com.concordium.sdk.types.Nonce;
 import lombok.*;
 
+/**
+ * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
+ */
+@Deprecated
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -38,7 +42,9 @@ public class EncryptedTransferWithMemoTransaction extends AccountTransaction {
      * @return Initialized {@link EncryptedTransferWithMemoTransaction}.
      * @throws TransactionCreationException On failure to create the Transaction from input params.
      *                                      Ex when any of the input param is NULL.
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
+    @Deprecated
     @Builder
     public static EncryptedTransferWithMemoTransaction from(
             final EncryptedAmountTransferData data,

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransactionFactory.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransactionFactory.java
@@ -13,6 +13,7 @@ import lombok.val;
  * TransactionFactory provides convenient functions for building a
  * {@link Transaction}
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
 public class TransactionFactory {
 
     /**
@@ -149,7 +150,9 @@ public class TransactionFactory {
      * creating a {@link TransferToEncryptedTransaction}
      *
      * @return the builder for a {@link TransferToEncryptedTransaction}
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
+    @Deprecated
     public static TransferToEncryptedTransaction.TransferToEncryptedTransactionBuilder newTransferToEncrypted() {
         return TransferToEncryptedTransaction.builder();
     }
@@ -160,8 +163,9 @@ public class TransactionFactory {
      * creating a {@link EncryptedTransferTransaction}
      *
      * @return the builder for a {@link EncryptedTransferTransaction}
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
-
+    @Deprecated
     public static EncryptedTransferTransaction.EncryptedTransferTransactionBuilder newEncryptedTransfer() {
         return EncryptedTransferTransaction.builder();
     }
@@ -172,7 +176,9 @@ public class TransactionFactory {
      * creating a {@link EncryptedTransferTransaction}
      *
      * @return the builder for a {@link EncryptedTransferTransaction}
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
+    @Deprecated
     public static EncryptedTransferTransaction.EncryptedTransferTransactionBuilder newEncryptedTransfer(
             CryptographicParameters cryptographicParameters,
             AccountEncryptedAmount accountEncryptedAmount,
@@ -204,8 +210,9 @@ public class TransactionFactory {
      * creating a {@link EncryptedTransferWithMemoTransaction}
      *
      * @return the builder for a {@link EncryptedTransferWithMemoTransaction}
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
-
+    @Deprecated
     public static EncryptedTransferWithMemoTransaction.EncryptedTransferWithMemoTransactionBuilder newEncryptedTransferWithMemo() {
         return EncryptedTransferWithMemoTransaction.builder();
     }
@@ -215,7 +222,9 @@ public class TransactionFactory {
      * creating a {@link EncryptedTransferWithMemoTransaction}
      *
      * @return the builder for a {@link EncryptedTransferWithMemoTransaction}
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
+    @Deprecated
     public static EncryptedTransferWithMemoTransaction.EncryptedTransferWithMemoTransactionBuilder newEncryptedTransferWithMemo(
             CryptographicParameters cryptographicParameters,
             AccountEncryptedAmount accountEncryptedAmount,

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferToEncryptedTransaction.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/TransferToEncryptedTransaction.java
@@ -8,7 +8,10 @@ import lombok.*;
 
 /**
  * Construct a transaction to transfer from public to encrypted balance of the sender account.
+ *
+ * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
  */
+@Deprecated
 @Getter
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
@@ -33,7 +36,9 @@ public class TransferToEncryptedTransaction extends AccountTransaction {
      * @return Initialized {@link TransferToEncryptedTransaction}.
      * @throws TransactionCreationException On failure to create the Transaction from input params.
      *                                      Ex when any of the input param is NULL.
+     * @deprecated Encrypted transfers are deprecated and partially removed since protocol version 7
      */
+    @Deprecated
     @Builder
     public static TransferToEncryptedTransaction from(
             final CCDAmount amount,


### PR DESCRIPTION
## Purpose

Deprecate encrypted transfers. They are deprecated and partially removed since protocol version 7.

## Changes

- Add deprecation annotations and Javadoc notices to builders, factory methods and classes associated with encrypted transfers

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
