### PR TITLE
Fix configure baker open status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Changed `openForDelegation` field in `ConfigureBakerPayload` from `boolean` to `OpenStatus`:
+  what used to be `false` is now `OpenStatus.OPEN_FOR_ALL`,
+  what used to be `true` is now `OpenStatus.CLOSED_FOR_NEW`,
+  and it is now possible to set `OpenStatus.CLOSED_FOR_ALL` as well
+
 ## 9.0.0
 - Support for Protocol 8
 - Added `ProtocolVersion.V8` corresponding to Protocol version 8

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/ConfigureBaking.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/ConfigureBaking.java
@@ -9,6 +9,7 @@ import com.concordium.sdk.requests.AccountQuery;
 import com.concordium.sdk.requests.BlockQuery;
 import com.concordium.sdk.responses.accountinfo.AccountInfo;
 import com.concordium.sdk.responses.blockitemstatus.FinalizedBlockItem;
+import com.concordium.sdk.responses.transactionstatus.OpenStatus;
 import com.concordium.sdk.responses.transactionstatus.PartsPerHundredThousand;
 import com.concordium.sdk.transactions.*;
 import com.concordium.sdk.types.AccountAddress;
@@ -63,7 +64,7 @@ public class ConfigureBaking implements Callable<Integer> {
                 .sender(sender)
                 .payload(ConfigureBakerPayload.builder()
                         .capital(CCDAmount.from(10000))
-                        .openForDelegation(true)
+                        .openForDelegation(OpenStatus.OPEN_FOR_ALL)
                         .restakeEarnings(true)
                         .bakingRewardCommission(PartsPerHundredThousand.from(5000))
                         .finalizationRewardCommission(PartsPerHundredThousand.from(100000))

--- a/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/ConfigureBaking.java
+++ b/concordium-sdk-examples/src/main/java/com/concordium/sdk/examples/ConfigureBaking.java
@@ -72,6 +72,7 @@ public class ConfigureBaking implements Callable<Integer> {
                         .keysWithProofs(
                                 ConfigureBakerKeysPayload
                                         .getNewConfigureBakerKeysPayload(sender, bakerkeys))
+                        .suspended(false)
                         .build())
                 .build();
         Hash hash = client.sendTransaction(tx);

--- a/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/ClientV2MapperExtensions.java
@@ -79,7 +79,6 @@ import com.concordium.sdk.responses.poolstatus.PendingChangeRemovePool;
 import com.concordium.sdk.responses.rewardstatus.RewardsOverview;
 import com.concordium.sdk.responses.smartcontracts.ContractVersion;
 import com.concordium.sdk.responses.transactionstatus.DelegationTarget;
-import com.concordium.sdk.responses.transactionstatus.OpenStatus;
 import com.concordium.sdk.responses.transactionstatus.PartsPerHundredThousand;
 import com.concordium.sdk.transactions.AccountTransaction;
 import com.concordium.sdk.transactions.InitContractPayload;
@@ -631,22 +630,9 @@ interface ClientV2MapperExtensions {
     static BakerPoolInfo to(com.concordium.grpc.v2.BakerPoolInfo poolInfo) {
         return BakerPoolInfo.builder()
                 .metadataUrl(poolInfo.getUrl())
-                .openStatus(to(poolInfo.getOpenStatus()))
+                .openStatus(com.concordium.sdk.responses.transactionstatus.OpenStatus.from(poolInfo.getOpenStatus()))
                 .commissionRates(CommissionRates.from(poolInfo.getCommissionRates()))
                 .build();
-    }
-
-    static OpenStatus to(com.concordium.grpc.v2.OpenStatus openStatus) {
-        switch (openStatus) {
-            case OPEN_STATUS_OPEN_FOR_ALL:
-                return OpenStatus.OPEN_FOR_ALL;
-            case OPEN_STATUS_CLOSED_FOR_NEW:
-                return OpenStatus.CLOSED_FOR_NEW;
-            case OPEN_STATUS_CLOSED_FOR_ALL:
-                return OpenStatus.CLOSED_FOR_ALL;
-            default:
-                throw new IllegalArgumentException();
-        }
     }
 
     static com.concordium.sdk.responses.AccountIndex to(AccountIndex index) {

--- a/concordium-sdk/src/main/java/com/concordium/sdk/transactions/ConfigureBakerPayload.java
+++ b/concordium-sdk/src/main/java/com/concordium/sdk/transactions/ConfigureBakerPayload.java
@@ -1,5 +1,6 @@
 package com.concordium.sdk.transactions;
 
+import com.concordium.sdk.responses.transactionstatus.OpenStatus;
 import com.concordium.sdk.responses.transactionstatus.PartsPerHundredThousand;
 import com.concordium.sdk.types.UInt16;
 import com.concordium.sdk.types.UInt32;
@@ -32,7 +33,7 @@ public class ConfigureBakerPayload {
     /**
      * Whether the pool is open for delegators.
      */
-    private final Boolean openForDelegation;
+    private final OpenStatus openForDelegation;
     /**
      * The key/proof pairs to verify the baker.
      */
@@ -83,7 +84,7 @@ public class ConfigureBakerPayload {
         it *= 2;
         bitValue |= ((this.metadataUrl != null) ? it : 0);
         it *= 2;
-        bitValue |= (!Objects.isNull(this.transactionFeeCommission ) ? it : 0);
+        bitValue |= (!Objects.isNull(this.transactionFeeCommission) ? it : 0);
         it *= 2;
         bitValue |= (!Objects.isNull(this.bakingRewardCommission) ? it : 0);
         it *= 2;
@@ -123,7 +124,20 @@ public class ConfigureBakerPayload {
         }
 
         if (this.openForDelegation != null) {
-            val openForDelegationByte = (byte) (this.openForDelegation ? 1 : 0);
+            byte openForDelegationByte;
+            switch (this.openForDelegation) {
+                case OPEN_FOR_ALL:
+                    openForDelegationByte = 0;
+                    break;
+                case CLOSED_FOR_NEW:
+                    openForDelegationByte = 1;
+                    break;
+                case CLOSED_FOR_ALL:
+                    openForDelegationByte = 2;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unrecognized open status " + this.openForDelegation);
+            }
             openForDelegationBuffer = createNotNullBuffer(new byte[]{openForDelegationByte});
             bufferLength += TransactionType.BYTES;
         }

--- a/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/ClientV2GetAccountInfoTest.java
@@ -465,15 +465,15 @@ public class ClientV2GetAccountInfoTest {
     public void mapOpenStatusTest() {
         assertEquals(
                 com.concordium.sdk.responses.transactionstatus.OpenStatus.OPEN_FOR_ALL,
-                ClientV2MapperExtensions.to(OpenStatus.OPEN_STATUS_OPEN_FOR_ALL));
+                com.concordium.sdk.responses.transactionstatus.OpenStatus.from(OpenStatus.OPEN_STATUS_OPEN_FOR_ALL));
 
         assertEquals(
                 com.concordium.sdk.responses.transactionstatus.OpenStatus.CLOSED_FOR_ALL,
-                ClientV2MapperExtensions.to(OpenStatus.OPEN_STATUS_CLOSED_FOR_ALL));
+                com.concordium.sdk.responses.transactionstatus.OpenStatus.from(OpenStatus.OPEN_STATUS_CLOSED_FOR_ALL));
 
         assertEquals(
                 com.concordium.sdk.responses.transactionstatus.OpenStatus.CLOSED_FOR_NEW,
-                ClientV2MapperExtensions.to(OpenStatus.OPEN_STATUS_CLOSED_FOR_NEW));
+                com.concordium.sdk.responses.transactionstatus.OpenStatus.from(OpenStatus.OPEN_STATUS_CLOSED_FOR_NEW));
     }
 
     @Test

--- a/concordium-sdk/src/test/java/com/concordium/sdk/transactions/ConfigureBakerTransactionTest.java
+++ b/concordium-sdk/src/test/java/com/concordium/sdk/transactions/ConfigureBakerTransactionTest.java
@@ -2,10 +2,10 @@ package com.concordium.sdk.transactions;
 
 import com.concordium.sdk.crypto.bakertransactions.BakerKeys;
 import com.concordium.sdk.responses.BakerId;
+import com.concordium.sdk.responses.transactionstatus.OpenStatus;
 import com.concordium.sdk.responses.transactionstatus.PartsPerHundredThousand;
 import com.concordium.sdk.types.AccountAddress;
 import com.concordium.sdk.types.Nonce;
-import com.concordium.sdk.types.UInt32;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.Test;
@@ -25,7 +25,7 @@ public class ConfigureBakerTransactionTest {
         val payload = ConfigureBakerPayload.builder()
                 .capital(CCDAmount.fromMicro("14000000000"))
                 .restakeEarnings(true)
-                .openForDelegation(false)
+                .openForDelegation(OpenStatus.OPEN_FOR_ALL)
                 .keysWithProofs(ConfigureBakerKeysPayload.getNewConfigureBakerKeysPayload(accountAddress, bakerKeys))
                 .metadataUrl("abc@xyz.com")
                 .transactionFeeCommission(PartsPerHundredThousand.from(10000))
@@ -74,7 +74,7 @@ public class ConfigureBakerTransactionTest {
         val payload = ConfigureBakerPayload.builder()
                 .capital(CCDAmount.fromMicro("14000000000"))
                 .restakeEarnings(true)
-                .openForDelegation(false)
+                .openForDelegation(OpenStatus.OPEN_FOR_ALL)
                 .keysWithProofs(ConfigureBakerKeysPayload.getNewConfigureBakerKeysPayload(accountAddress, BakerKeys.createBakerKeys()))
                 .transactionFeeCommission(PartsPerHundredThousand.from(10000))
                 .bakingRewardCommission(PartsPerHundredThousand.from(10000))


### PR DESCRIPTION
## Purpose

Fix incorrect type and behavior in ConfigureBakerPayload

## Changes

- Changed `openForDelegation` field in `ConfigureBakerPayload` from `boolean` to `OpenStatus`: what used to be `false` is now `OpenStatus.OPEN_FOR_ALL`, what used to be `true` is now `OpenStatus.CLOSED_FOR_NEW`, and it is now possible to set `OpenStatus.CLOSED_FOR_ALL` as well
- Added `suspended` to the configure baking example

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
